### PR TITLE
Add a makefile with test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	@true


### PR DESCRIPTION
The "test" does not do anything useful yet, but this way, we can
already establish the final command to invoke in the centos-ci
integration.

Signed-off-by: Michael Adam <obnox@samba.org>