### PR TITLE
centos-ci: run "make test" instead of true

### DIFF
--- a/samba-integration-centos-ci-tests.sh
+++ b/samba-integration-centos-ci-tests.sh
@@ -56,9 +56,9 @@ then
 	git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
 	git checkout "pr_${ghprbPullId}"
 	
-	git rebase master
+	git rebase "${ghprbTargetBranch}"
 	if [ $? -ne 0 ] ; then
-	    echo "Unable to automatically merge master. Please rebase your patch"
+	    echo "Unable to automatically rebase to branch '${ghprbTargetBranch}'. Please rebase your PR!"
 	    exit 1
 	fi
 fi

--- a/samba-integration-centos-ci-tests.sh
+++ b/samba-integration-centos-ci-tests.sh
@@ -53,8 +53,8 @@ cd "${GIT_REPO_NAME}"
 # by default we clone the master branch, but maybe this was triggered through a PR?
 if [ -n "${ghprbPullId}" ]
 then
-	git fetch origin pull/${ghprbPullId}/head:pr_${ghprbPullId}
-	git checkout pr_${ghprbPullId}
+	git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
+	git checkout "pr_${ghprbPullId}"
 	
 	git rebase master
 	if [ $? -ne 0 ] ; then

--- a/samba-integration-centos-ci-tests.sh
+++ b/samba-integration-centos-ci-tests.sh
@@ -12,6 +12,7 @@ set -x
 
 GIT_REPO_NAME="samba-integration"
 GIT_REPO_URL="https://github.com/gluster/${GIT_REPO_NAME}.git"
+TEST_TARGET="test"
 
 # enable additional sources for yum
 # (SCL repository for Vagrant, epel for ansible)
@@ -73,8 +74,9 @@ scl enable sclo-vagrant1 -- \
 
 # time to run the tests:
 
+make "${TEST_TARGET}"
 # TODO: add real tests to execute
-true
+# When the tests use vagrant, run them like so:
 #echo make "${TEST_TARGET}" | scl enable sclo-vagrant1 bash
 
 # END


### PR DESCRIPTION
With https://github.com/gluster/samba-integration/pull/6, a Makefile
with target "test" should be added. Once we use that, we don't have to
modify this script any more to change what tests are run.

Signed-off-by: Michael Adam <obnox@samba.org>