### PR TITLE
centos-ci: bootstrap.sh: small fix.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 EXEC_BIN="$(basename $1)"
 scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$1" "root@$(cat $WORKSPACE/hosts):$EXEC_BIN"
-if [ -z $2 ];
+if [ -z "$2" ];
 then
     ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@$(cat $WORKSPACE/hosts)" "./$EXEC_BIN"
 else


### PR DESCRIPTION
If more than one variable is passed, then the bootstrap.sh errors with
something like
"/bootstrap.sh: line 7: [: ghprbPullId=8: binary operator expected"

Making this safer.

Signed-off-by: Michael Adam <obnox@samba.org>