### PR TITLE
centos-ci: add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	ghprbPullId='' ./samba-integration-centos-ci-tests.sh

--- a/samba-integration-centos-ci-tests.sh
+++ b/samba-integration-centos-ci-tests.sh
@@ -56,7 +56,7 @@ then
 	git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
 	git checkout "pr_${ghprbPullId}"
 	
-	git rebase "${ghprbTargetBranch}"
+	git rebase "origin/${ghprbTargetBranch}"
 	if [ $? -ne 0 ] ; then
 	    echo "Unable to automatically rebase to branch '${ghprbTargetBranch}'. Please rebase your PR!"
 	    exit 1


### PR DESCRIPTION
With a "test" target that will invoke the script so that it will run
make test from the master branch.

Signed-off-by: Michael Adam <obnox@samba.org>