### PR TITLE
centos-ci: always run make test in vagrant-enabled shell

### DIFF
--- a/samba-integration-centos-ci-tests.sh
+++ b/samba-integration-centos-ci-tests.sh
@@ -74,9 +74,7 @@ scl enable sclo-vagrant1 -- \
 
 # time to run the tests:
 
-make "${TEST_TARGET}"
 # TODO: add real tests to execute
-# When the tests use vagrant, run them like so:
-#echo make "${TEST_TARGET}" | scl enable sclo-vagrant1 bash
+echo make "${TEST_TARGET}" | scl enable sclo-vagrant1 bash
 
 # END


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@samba.org>