### PR TITLE
node.setup: use artifacts.ci.centos.org as source of the Gluster repo

### DIFF
--- a/vagrant/roles/node.setup/tasks/main.yml
+++ b/vagrant/roles/node.setup/tasks/main.yml
@@ -9,7 +9,7 @@
     state: latest
 
 - name: Enable GlusterFS nightly rpms repository
-  command: yum-config-manager --add-repo https://ci.centos.org/artifacts/gluster/nightly/master.repo
+  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
 
 - name: Install GlusterFS rpms
   yum:


### PR DESCRIPTION
artifacts.ci.centos.org is the official name to use for the artifacts
that are built through a CI job. It seems ci.centos.org/artifacts uses
some form of redirection that does not work from within the CI
environment.

CI jobs fail with 404 errors while downloading https://ci.centos.org/artifacts/gluster/nightly/master.repo