### PR TITLE
Sp remove duplicate state

### DIFF
--- a/vagrant/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/ctdb.setup/tasks/main.yml
@@ -17,7 +17,6 @@
   firewalld:
     service: ctdb
     permanent: yes
-    state: present
     state: enabled
 
 - name: Add recovery lock to ctdb.conf


### PR DESCRIPTION
Generates a warning message.
"
/home/vagrant/ansible/roles/ctdb.setup/tasks/main.yml, line 36, column 5, found
a duplicate dict key (state). Using last defined value only.
"
