### PR TITLE
ssh-config ends up with trailing " for IdentityFile

### DIFF
--- a/vagrant/roles/local.prep/tasks/main.yml
+++ b/vagrant/roles/local.prep/tasks/main.yml
@@ -38,5 +38,5 @@
 - name: modify ssh-config-setup
   replace:
     path: ./ansible/ssh-config-setup
-    regexp: "IdentityFile .*\\.vagrant\\.d/insecure_private_key"
+    regexp: "IdentityFile .*"
     replace: "IdentityFile /home/vagrant/ansible/vagrant_insecure_private_ssh_key"


### PR DESCRIPTION
    ssh-config ends up with trailing " for IdentityFile
    
    On a Centos 5 machine, vagrant ssh-config generates an ssh-config with
    the file for IdentityFile enclosed in quotes. The current regex doesn't
    take care of trailing ".
    
    We do not need an elaborate regex for the ansible lininfile call and
    replace the existing one with a simpler one.
    
    Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>
