### PR TITLE
samba-build: provide tdb-tools and ldb-tools from samba-client

### DIFF
--- a/packaging/samba.spec.j2
+++ b/packaging/samba.spec.j2
@@ -298,6 +298,12 @@ Requires: libwbclient = %{samba_depver}
 Provides: samba4-client = %{samba_depver}
 Obsoletes: samba4-client < %{samba_depver}
 
+Provides: ldb-tools = %{samba_depver}
+Obsoletes: ldb-tools < %{samba_depver}
+
+Provides: tdb-tools = %{samba_depver}
+Obsoletes: tdb-tools < %{samba_depver}
+
 Requires(post): %{_sbindir}/update-alternatives
 Requires(postun): %{_sbindir}/update-alternatives
 


### PR DESCRIPTION
This is in attempt to overcome the dependency problem that
ctdb requires tdb-tools and our samba-client package provides
the tools but they currently conflict with the system tdb-tools package.

Signed-off-by: Michael Adam <obnox@samba.org>