### PR TITLE
Update all nodes before starting the install process

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -3,10 +3,13 @@ INVENTORY := ./vagrant_ansible_inventory
 local:
 	@ansible-playbook --inventory localhost, local.yml
 
+hosts.update.only:
+	@ansible-playbook --inventory=$(INVENTORY) hosts.update.yml
+
 setup.prep.only:
 	@ansible-playbook --inventory=$(INVENTORY) setup.prep.yml
 
-setup.prep: local setup.prep.only
+setup.prep: local hosts.update.only setup.prep.only
 
 setup.prep.copy:
 	@ansible-playbook --inventory=$(INVENTORY) --start-at-task "copy ansible playbooks to setup machine" setup.prep.yml
@@ -19,5 +22,4 @@ setup.cluster.only:
 
 setup.cluster: setup.prep setup.test.only setup.cluster.only
 
-
-.PHONY: local setup.prep.only setup.prep setup.test.only setup.cluster.only setup.cluster
+.PHONY: local hosts.update.only setup.prep.only setup.prep setup.test.only setup.cluster.only setup.cluster

--- a/vagrant/hosts.update.yml
+++ b/vagrant/hosts.update.yml
@@ -1,0 +1,11 @@
+#
+# Update all nodes
+#
+- hosts: all
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Perform a complete update
+      yum:
+        name: '*'
+        state: latest


### PR DESCRIPTION
Present the setup scripts with completely updated hosts.
Updating in parallel will also speed up the install process.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>

Modifications as discussed in #25 