### PR TITLE
Use ssh to call setup

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -1,4 +1,5 @@
 INVENTORY := ./vagrant_ansible_inventory
+VSSH := ssh -F ansible/ssh-config-setup -i /root/.vagrant.d/insecure_private_key
 
 local:
 	@ansible-playbook --inventory localhost, local.yml
@@ -18,7 +19,7 @@ setup.test.only:
 	@ansible-playbook --inventory=$(INVENTORY) setup.test.yml
 
 setup.cluster.only:
-	@ansible-playbook --inventory=$(INVENTORY) setup.run.yml
+	@$(VSSH) setup "make -C /home/vagrant/ansible setup.cluster"
 
 setup.cluster: setup.prep setup.test.only setup.cluster.only
 

--- a/vagrant/roles/setup.prep/tasks/main.yml
+++ b/vagrant/roles/setup.prep/tasks/main.yml
@@ -33,8 +33,13 @@
   file:
     path: /home/vagrant/ansible/vagrant_insecure_private_ssh_key
     mode: u=rw,g=,o=
+    owner: vagrant
+    group: vagrant
 
 - name: copy ssh config in place
   copy:
-   src: ansible/ssh-config-setup
-   dest: /home/vagrant/.ssh/config
+    src: ansible/ssh-config-setup
+    dest: /home/vagrant/.ssh/config
+    mode: 0600
+    owner: vagrant
+    group: vagrant

--- a/vagrant/roles/setup.run/tasks/main.yml
+++ b/vagrant/roles/setup.run/tasks/main.yml
@@ -1,2 +1,0 @@
-- name: run the setup playbook on the setup machine
-  command: ansible-playbook -i /home/vagrant/ansible/vagrant_ansible_inventory /home/vagrant/ansible/site.yml

--- a/vagrant/setup.run.yml
+++ b/vagrant/setup.run.yml
@@ -1,8 +1,0 @@
-#
-# run the cluster creation on the setup machine
-#
-- hosts: setup
-  become: yes
-  become_method: sudo
-  roles:
-    - setup.run


### PR DESCRIPTION
Instead of calling the ansible scripts in setup through ssh, we should use ssh. This allows us to follow the execution steps as it happens instead of seeing no updates while we setup the cluster nodes and the clients. 
