### PR TITLE
Fix calling ssh in vagrant/Makefile

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -1,5 +1,4 @@
 INVENTORY := ./vagrant_ansible_inventory
-VSSH := ssh -F ansible/ssh-config-setup -i /root/.vagrant.d/insecure_private_key
 
 local:
 	@ansible-playbook --inventory localhost, local.yml
@@ -19,7 +18,7 @@ setup.test.only:
 	@ansible-playbook --inventory=$(INVENTORY) setup.test.yml
 
 setup.cluster.only:
-	@$(VSSH) setup "make -C /home/vagrant/ansible setup.cluster"
+	@vagrant ssh setup -c "make -C /home/vagrant/ansible setup.cluster"
 
 setup.cluster: setup.prep setup.test.only setup.cluster.only
 


### PR DESCRIPTION
We cannot call ssh using an absolute path to the insecure key. Doing so
breaks the setup for those running the tests on their local machine.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>