### PR TITLE
Fix calling ssh in the Makefile

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -1,5 +1,5 @@
 INVENTORY := ./vagrant_ansible_inventory
-VSSH := ssh -F ansible/ssh-config-setup -i /root/.vagrant.d/insecure_private_key
+VSSH := ssh -F ssh-config-host
 
 local:
 	@ansible-playbook --inventory localhost, local.yml


### PR DESCRIPTION
By accident an ssh command using /root/.vagrant.d/insecure_private_key
was commited into the tree. Fix this by using the pre-created
ssh-config-host.

Signed-off-by: Michael Adam <obnox@samba.org>