### PR TITLE
Fix regression in setting up vms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test
 test:
-	@$(MAKE) -C vagrant setup.cluster
+	@$(MAKE) -C vagrant setup.site

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -23,4 +23,9 @@ setup.cluster.only:
 
 setup.cluster: setup.prep setup.test.only setup.cluster.only
 
-.PHONY: local hosts.update.only setup.prep.only setup.prep setup.test.only setup.cluster.only setup.cluster
+setup.clients:
+	@$(VSSH) setup "make -C /home/vagrant/ansible setup.clients"
+
+setup.site: setup.cluster setup.clients
+
+.PHONY: local hosts.update.only setup.prep.only setup.prep setup.test.only setup.cluster.only setup.cluster setup.clients setup.site

--- a/vagrant/ansible/Makefile
+++ b/vagrant/ansible/Makefile
@@ -7,4 +7,9 @@ setup.test:
 setup.cluster:
 	@ansible-playbook -i $(INVENTORY) ./setup-cluster.yml
 
-.PHONY: setup.cluster
+setup.clients:
+	@ansible-playbook -i $(INVENTORY) ./setup-clients.yml
+
+setup.site: setup.cluster setup.clients
+
+.PHONY: setup.cluster setup.clients setup.site


### PR DESCRIPTION
The patch to call over ssh uses the make target setup.cluster in vagrant/ansible/Makefile. This only sets up the cluster nodes and does not setup the client.

This is a regression as we have now transitioned to use site.yml which in turn calls both  setup-cluster.yml and setup-clients.yml.

