### PR TITLE
Remove unneeded debugging output

### DIFF
--- a/vagrant/roles/setup.test/tasks/main.yml
+++ b/vagrant/roles/setup.test/tasks/main.yml
@@ -1,10 +1,2 @@
-- name: cat /etc/resolv.conf
-  command: cat /etc/resolv.conf
-  register: resolv_conf_contents
-
-- name: content of /etc/resolv.conf
-  debug:
-    var: resolv_conf_contents.stdout_lines
-
 - name: test playbook node connectivity on the setup machine
   command: ansible-playbook -i /home/vagrant/ansible/vagrant_ansible_inventory /home/vagrant/ansible/test.local.yml


### PR DESCRIPTION
For debugging network connectivity issues, we printed the contents
of /etc/resolv.conf. This is not needed any more. Removing it.

Signed-off-by: Michael Adam <obnox@samba.org>