### PR TITLE
Tests smbtorture

### DIFF
--- a/testcases/smbtorture-test/run_test
+++ b/testcases/smbtorture-test/run_test
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+test_dir=$(cd `dirname $0` && pwd)
+$test_dir/smbtorture-test.py $1 $test_dir/smbtorture-tests-info.yml

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -1,0 +1,50 @@
+#!/bin/python
+
+# Run smbtorture tests
+
+import testhelper
+import sys, os
+import yaml
+
+smbtorture_exec = "/bin/smbtorture"
+output = testhelper.get_tmp_file("/tmp")
+
+def smbtorture(mount_params, test, output):
+    cmd = "%s --user=%s%%%s //%s/%s %s >%s 2>&1" % (
+                                            smbtorture_exec,
+                                            mount_params["username"],
+                                            mount_params["password"],
+                                            mount_params["host"],
+                                            mount_params["share"],
+                                            test,
+                                            output
+                                         )
+    ret = os.system(cmd)
+    return ret == 0
+
+if (len(sys.argv) != 3):
+    print("Usage: %s <test-info.yml> <smbtorture-tests-info.yml>" % (sys.argv[0]))
+    exit(1)
+
+test_info_file = sys.argv[1]
+test_info = testhelper.read_yaml(test_info_file)
+mount_params = testhelper.get_default_mount_params(test_info)
+
+smbtorture_tests_info_file = sys.argv[2]
+
+with open(smbtorture_tests_info_file) as f:
+    smbtorture_info = yaml.safe_load(f)
+
+#First the expected pass tests
+print("")
+for test in smbtorture_info:
+    torture_test = list(test.keys())[0]
+    print("\t{:<20}".format(torture_test)),
+    ret = smbtorture(mount_params, torture_test, output)
+    if (ret != test[torture_test]["expected_ret"]):
+        print("{:>10}".format("[Failed]"))
+        print("\n")
+        with open(output) as f:
+            print(f.read())
+        assert False
+    print("{:>10}".format("[OK]"))

--- a/testcases/smbtorture-test/smbtorture-tests-info.yml
+++ b/testcases/smbtorture-test/smbtorture-tests-info.yml
@@ -1,0 +1,7 @@
+---
+- smb2.rw:
+    expected_ret: True
+
+- smb2.read:
+    expected_ret: True
+

--- a/testcases/tests
+++ b/testcases/tests
@@ -1,3 +1,4 @@
 mount-test
 consistency-test
+smbtorture-test
 


### PR DESCRIPTION
Applies after PR 58.

Setting label to do not merge since a couple of smbtorture tests are failing at the moment. The tests are expected to be checked and fixed before merging with the other tests.