### PR TITLE
Upgrade jinja2 python library on setup

### DIFF
--- a/vagrant/roles/setup.prep/tasks/main.yml
+++ b/vagrant/roles/setup.prep/tasks/main.yml
@@ -8,6 +8,16 @@
     name: epel-release
     state: latest
 
+- name: Install Python2 pip
+  yum:
+    name: python2-pip
+    state: installed
+
+- name: Install pip jinja2 library
+  pip:
+    name: jinja2
+    state: latest
+
 - name: add copr to get gluster-ansible from sac
   block:
 


### PR DESCRIPTION
We use pip to upgrade the jinja2 library to the latest version. This is
required when re-running the scripts to install the test machines.

bug: https://github.com/gluster/samba-integration/issues/60

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>

Using this patch, we get past the problem in gluster-infra.
We hit another problem when creating test users in samba. But that is caused by another issue.