### PR TITLE
Remove some defaults from smb.conf template

### DIFF
--- a/vagrant/ansible/roles/samba-glusterfs.setup/templates/smb.conf.j2
+++ b/vagrant/ansible/roles/samba-glusterfs.setup/templates/smb.conf.j2
@@ -1,25 +1,16 @@
 [global]
 netbios name = {{ samba_netbios_name }}
 clustering = yes
-passdb backend = tdbsam
 log file = /var/log/samba/log.%m
 max log size = 0
 server string = Samba server version %v
 workgroup = MYGROUP
 security = user
 
-client signing = auto
-
 kernel share modes = No
 map archive = No
-map hidden = no
-map read only = no
 posix locking = No
 kernel change notify = no
-kernel oplocks = no
-
-max protocol = SMB3
-store dos attributes = yes
 
 load printers = no
 printcap name = /dev/null


### PR DESCRIPTION
From man [smb.conf(5)](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html):

> passdb backend (G)
> Default: passdb backend = tdbsam
 
> client signing (G)
> When set to auto or default, SMB signing is offered, but not enforced.
> Default: client signing = default
 
> map hidden (S)
> Default: map hidden = no
 
> map readonly (S)
> Default: map readonly = no
 
> kernel oplocks (S)
> Default: kernel oplocks = no

> max protocol
> This parameter is a synonym for server max protocol.

> server max protocol (G)
> Default: server max protocol = SMB3

> store dos attributes (S)
> Default: store dos attributes = yes