### PR TITLE
Configure GlusterFS nightly repo in common.prep

### DIFF
--- a/vagrant/ansible/roles/client.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/main.yml
@@ -1,6 +1,3 @@
-- name: Enable GlusterFS nightly rpms repository
-  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
-
 - name: Install required packages
   yum:
     name:

--- a/vagrant/ansible/roles/common.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/common.prep/tasks/main.yml
@@ -28,6 +28,9 @@
     name: epel-release
     state: latest
 
+- name: Enable GlusterFS nightly rpms repository
+  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
+
 - name: add copr to get compat-gnutls34 (needed for centos 7)
   block:
 

--- a/vagrant/ansible/roles/node.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/node.prep/tasks/main.yml
@@ -18,9 +18,6 @@
       delegate_to: "{{ item }}"
       with_items: "{{ gluster_cluster_hosts }}"
 
-- name: Enable GlusterFS nightly rpms repository
-  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
-
 - name: Install GlusterFS rpms
   yum:
     name: "{{ gluster_rpms }}"


### PR DESCRIPTION
_common.prep_ is always invoked before _node.prep_ and _client.prep_ roles from _setup-cluster_ and _setup-clients_ playbooks respectively.