### PR TITLE
Remove duplicate call the make test

### DIFF
--- a/vagrant/ansible/roles/client.test.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/tasks/main.yml
@@ -13,7 +13,3 @@
     group: root
     state: link
 
-- name: Run tests
-  command:
-    chdir: /root/samba-integration-tests
-    cmd: make test


### PR DESCRIPTION
We should not be calling make test from client.test.prep. This should
have been removed when the original client.test was split into
client.test.prep and client.test.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>