### PR TITLE
Use vfs_acl_xattr along with vfs_glusterfs

### DIFF
--- a/vagrant/ansible/roles/samba-glusterfs.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/samba-glusterfs.setup/tasks/main.yml
@@ -64,6 +64,12 @@
         state: absent
   run_once: true
 
+- name: Add acl_xattr VFS module
+  lineinfile:
+    dest: /etc/samba/smb.conf
+    line: "vfs objects = acl_xattr glusterfs"
+    regexp: "vfs objects"
+
 - name: Create test users
   user:
     name: "{{ item.username }}"


### PR DESCRIPTION
vfs_acl_xattr helps us in achieving complete support for NT ACLs.

Note:
Still we have another problem in running `make test` second time. This is because _smb.conf_ is forcefully copied over on every run which removes `[gluster-$VOLNAME`] share section (which was automatically added by GlusterFS hook scripts) and `user.smb` volume option is not set/executed from second time onvwards.