### PR TITLE
tests: fix result of new smb2.rw.invalid run

### DIFF
--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -10,7 +10,7 @@ smbtorture_exec = "/bin/smbtorture"
 output = testhelper.get_tmp_file("/tmp")
 
 def smbtorture(mount_params, test, output):
-    cmd = "%s --user=%s%%%s //%s/%s %s >%s 2>&1" % (
+    cmd = "%s --target=samba3 --user=%s%%%s //%s/%s %s >%s 2>&1" % (
                                             smbtorture_exec,
                                             mount_params["username"],
                                             mount_params["password"],


### PR DESCRIPTION
Some smbtorture tests behave slightly differently
when they are running against samba. The new smb2.rw.invalid
test is such a test. For these cases, smbtorture has the
`--target` option. `--target=samba3` indicates that this is
run against a samba smbd server.

Since we are always running against the smbd server here,
this patch adds the `--target=samba3` option to our smbtorture
commandline.

Signed-off-by: Michael Adam <obnox@samba.org>