### PR TITLE
Centos-ci: enable testing prs to tests branch

### DIFF
--- a/samba-integration-centos-ci-tests.sh
+++ b/samba-integration-centos-ci-tests.sh
@@ -12,6 +12,8 @@ set -x
 
 GIT_REPO_NAME="samba-integration"
 GIT_REPO_URL="https://github.com/gluster/${GIT_REPO_NAME}.git"
+TESTS_GIT_BRANCH="tests"
+TEST_EXTRA_VARS=""
 TEST_TARGET="test"
 SCRIPT_GIT_BRANCH="centos-ci"
 SCRIPT_NAME="$(basename $0)"
@@ -35,24 +37,31 @@ cd "${GIT_REPO_NAME}"
 # by default we clone the master branch, but maybe this was triggered through a PR?
 if [ -n "${ghprbPullId}" ]
 then
-	git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
-	git checkout "pr_${ghprbPullId}"
-	
-	git rebase "origin/${ghprbTargetBranch}"
-	if [ $? -ne 0 ] ; then
-	    echo "Unable to automatically rebase to branch '${ghprbTargetBranch}'. Please rebase your PR!"
-	    exit 1
-	fi
+	if [ "${ghprbTargetBranch}" = "${TESTS_GIT_BRANCH}" ]; then
+		# A PR against the tests branch:
+		# Just invoke "make test" from master with the corresponding
+		# parameters.
+		TEST_EXTRA_VARS="test_repo=${GIT_REPO_URL} test_repo_pr=${ghprbPullId}"
+	else
+		git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
+		git checkout "pr_${ghprbPullId}"
+		
+		git rebase "origin/${ghprbTargetBranch}"
+		if [ $? -ne 0 ] ; then
+		    echo "Unable to automatically rebase to branch '${ghprbTargetBranch}'. Please rebase your PR!"
+		    exit 1
+		fi
 
-	# If the PR is on the branch that contains this script,
-	# and the script has changed in the PR, make sure we
-	# restart the PR version of the script to test the
-	# proposed changes, since the centos-ci is running
-	# the merged copy.
-	if [ "${ghprbTargetBranch}" = "${SCRIPT_GIT_BRANCH}" ]; then
-		if ! git diff --quiet ./"${SCRIPT_NAME}" "${SCRIPT_PATH}" ; then
-			echo "Script changed in PR ==> starting over..."
-			exec "./${SCRIPT_NAME}"
+		# If the PR is on the branch that contains this script,
+		# and the script has changed in the PR, make sure we
+		# restart the PR version of the script to test the
+		# proposed changes, since the centos-ci is running
+		# the merged copy.
+		if [ "${ghprbTargetBranch}" = "${SCRIPT_GIT_BRANCH}" ]; then
+			if ! git diff --quiet ./"${SCRIPT_NAME}" "${SCRIPT_PATH}" ; then
+				echo "Script changed in PR ==> starting over..."
+				exec "./${SCRIPT_NAME}"
+			fi
 		fi
 	fi
 fi
@@ -120,6 +129,6 @@ vagrant box add "https://vagrantcloud.com/centos/7" --provider "libvirt" \
 # run the tests
 #
 
-make "${TEST_TARGET}"
+EXTRA_VARS="${TEST_EXTRA_VARS}" make "${TEST_TARGET}"
 
 # END


### PR DESCRIPTION
This detects if running a PR against the "tests" branch and just
adds the extra args to the invocation of "make test" on the master
branch. This is enabled by having merged
https://github.com/gluster/samba-integration/pull/73 .

Signed-off-by: Michael Adam <obnox@samba.org>