### PR TITLE
Human readable output on failure in running tests

### DIFF
--- a/vagrant/ansible/Makefile
+++ b/vagrant/ansible/Makefile
@@ -14,7 +14,7 @@ setup.clients:
 	@ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./setup-clients.yml
 
 client.test:
-	@ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./client-test.yml
+	@ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./client-test.yml
 
 setup.site: setup.cluster setup.clients client.test
 


### PR DESCRIPTION
Failure in running tests should result in human readable output.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>