### PR TITLE
tests: improve comment for consistency-check test

### DIFF
--- a/testcases/consistency-test/consistency-check.py
+++ b/testcases/consistency-test/consistency-check.py
@@ -1,6 +1,10 @@
 #!/bin/python
 
-# Test mounts a cifs share, creates a new file on it, writes to it, deletes the file and unmounts
+# This test first mounts a cifs share, creates a new file on it,
+# writes to it, and unmounts the share, and then tests that it
+# can get exactly the data written into the file through various
+# possible ways of mounting the share (combinations of users and
+# ip addresses).
 
 import testhelper
 import os, sys


### PR DESCRIPTION
The comment in the consistency-check test seems
to have been copy-and-pasted from the mount-test and
does not correctly describe what this test does.
This patch updates the comment to fix this.

Signed-off-by: Michael Adam <obnox@samba.org>