### PR TITLE
Exclude glusterfs packages from centos repos

### DIFF
--- a/vagrant/ansible/roles/common.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/common.prep/tasks/main.yml
@@ -28,6 +28,9 @@
     name: epel-release
     state: latest
 
+- name: Exclude glusterfs* for all repos except for the ones added after this point
+  command: yum-config-manager --setopt=\*.exclude=glusterfs\* --save
+
 - name: Enable GlusterFS nightly rpms repository
   command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
 


### PR DESCRIPTION
Yum refuses to proceed with the installation if multiple packages
provide the same dependency.

We hit the following issue when installing glusterfs-server.

"
Error: Package: glusterfs-server-20200609.955bfd5-0.0.el7.x86_64 (gluster-nightly-master)
Requires: libgfrpc.so.0()(64bit)
Available: glusterfs-libs-6.0-29.el7.x86_64 (base)
libgfrpc.so.0()(64bit)
Available: libgfrpc0-20200609.955bfd5-0.0.el7.x86_64 (gluster-nightly-master)
libgfrpc.so.0()(64bit)
"
To fix this, we exclude all glusterfs* packages from repos before we
install the gluster-nightly-master repo. This ensures that the glusterfs
packages from the standard repos provided by centos are not picked.

Signed-off-by: Sachin Prabhu<sprabhu@redhat.com>