### PR TITLE
Install python36-iso8601 on client

### DIFF
--- a/vagrant/ansible/roles/client.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/main.yml
@@ -19,6 +19,7 @@
     executable: /usr/bin/pip3
     name:
       - PyYAML
+      - iso8601
 
 - debug:
     msg: "{{ ctdb_network_public_interfaces }}"


### PR DESCRIPTION
This is needed for the filter-subunit script used in smbtorture tests.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>

This is required by the selftest scripts being uploaded as part of the update to the smbtorture tests(PR #95). These scripts use python 3 and hence we need to install the python 3 iso8601 package. 


Unfortunately, this is a RHEL 7 specific package name. The ansible script will not work when used with the RHEL 8 packages when we move to it. However I suspect that this wouldn't be the only area of concern.