### PR TITLE
Add separate sections for pip2 and pip3

### DIFF
--- a/vagrant/ansible/roles/client.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/main.yml
@@ -8,9 +8,17 @@
       - git
     state: latest
 
-- name: Install Python yaml package
+#This is a temporary section while we move scripts to use python 3
+- name: Install Python 2 modules
   pip:
-    name: PyYAML
+    name:
+      - PyYAML
+
+- name: Install Python 3 modules
+  pip:
+    executable: /usr/bin/pip3
+    name:
+      - PyYAML
 
 - debug:
     msg: "{{ ctdb_network_public_interfaces }}"


### PR DESCRIPTION
CentOS 7 has python versions 2.7 and 3.8 installed. When using pip to
install these modules, the module location depends on the version we are
installing for. We use the default python location for all our
python scripts used in the test module but the newer selftest modules
requires python 3. This is making it difficult to maintain using the
right version of modules without running OS specific calls.

To avoid these versioning issues, we plan on moving our scripts to
python 3 and while we transition, we temporarily use pip for both python
2 and python 3. We intend on removing the section for python 2 in the
  near future.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>

Step 1) Update to use both pip2 and pip3. 
Step 2) Update tests scripts to use python3
Step 3) Remove pip2

We are at Step 1.