### PR TITLE
    Change testscripts to  use Python3

### DIFF
--- a/testcases/consistency-test/consistency-check.py
+++ b/testcases/consistency-test/consistency-check.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 # This test first mounts a cifs share, creates a new file on it,
 # writes to it, and unmounts the share, and then tests that it

--- a/testcases/mount-test/mount-test.py
+++ b/testcases/mount-test/mount-test.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 # Test mounts a cifs share, creates a new file on it, writes to it, deletes the file and unmounts
 

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 # Run smbtorture tests
 

--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -71,7 +71,7 @@ def get_mount_parameter(test_info, share, combonum):
     """
     if (combonum > get_total_mount_parameter_combinations(test_info)):
         assert False, "Invalid combination number"
-    num_public = combonum / len(test_info["test_users"])
+    num_public = int(combonum / len(test_info["test_users"]))
     num_users = combonum % len(test_info["test_users"])
     return gen_mount_params(
         test_info["public_interfaces"][num_public],


### PR DESCRIPTION
The new selftest helpers require python3. While out own scripts use the default python interpreter which for CentOS 7 is python2. On systems with both versions installed, we need to decide which versions to install a particluar module for. 
    
To avoid confusion due to differring versions, we have decided to stick to Python3 for all our python scripts.


Step 1) Update to use both pip2 and pip3.
Step 2) Update tests scripts to use python3
Step 3) Remove pip2

We are at Step 2.
