### PR TITLE
Remove temporary pip2 section

### DIFF
--- a/vagrant/ansible/roles/client.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/main.yml
@@ -8,12 +8,6 @@
       - git
     state: latest
 
-#This is a temporary section while we move scripts to use python 3
-- name: Install Python 2 modules
-  pip:
-    name:
-      - PyYAML
-
 - name: Install Python 3 modules
   pip:
     executable: /usr/bin/pip3


### PR DESCRIPTION
We have now moved over to python3 and no longer need the section to
install python modules using pip2.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>

Step 1) Update to use both pip2 and pip3.
Step 2) Update tests scripts to use python3
Step 3) Remove pip2

We are at Step 3, the last step.