### PR TITLE
Conditionally build ctdb-tests package

### DIFF
--- a/packaging/samba.spec.j2
+++ b/packaging/samba.spec.j2
@@ -823,6 +823,7 @@ projects to store temporary data. If an application is already using TDB for
 temporary data it is very easy to convert that application to be cluster aware
 and use CTDB instead.
 
+%if %{with testsuite}
 ### CTDB-TEST
 %package -n ctdb-tests
 Summary: CTDB clustered database test suite
@@ -842,6 +843,8 @@ CTDB is a cluster implementation of the TDB database used by Samba and other
 projects to store temporary data. If an application is already using TDB for
 temporary data it is very easy to convert that application to be cluster aware
 and use CTDB instead.
+#endif with testsuite
+%endif
 #endif with_clustering_support
 %endif
 
@@ -2872,7 +2875,9 @@ fi
 %{_sbindir}/ctdbd
 %{_sbindir}/ctdbd_wrapper
 %{_bindir}/ctdb
+%if %{with testsuite}
 %{_bindir}/ctdb_local_daemons
+%endif
 %{_bindir}/ping_pong
 %{_bindir}/ltdbtool
 %{_bindir}/ctdb_diagnostics
@@ -2938,6 +2943,7 @@ fi
 
 %{_datadir}/ctdb/events/legacy/48.netbios.script
 
+%if %{with testsuite}
 %files -n ctdb-tests
 %doc ctdb/tests/README
 %{_bindir}/ctdb_run_tests
@@ -3719,6 +3725,9 @@ fi
 %{_datadir}/ctdb/tests/UNIT/tool/README
 %dir %{_datadir}/ctdb/tests/UNIT/tool/scripts
 %{_datadir}/ctdb/tests/UNIT/tool/scripts/local.sh
+
+#endif with testsuite
+%endif
 
 #endif with_clustering_support
 %endif


### PR DESCRIPTION
As per recent [commit](https://git.samba.org/?p=samba.git;a=commit;h=066c205e5fb0e28bb5cab61a583889bb85607fb9), ctdb test files and binaries are not getting installed by default unless it is being built standalone or _--enable-selftest_ is specified. Therefore build ctdb-tests package accordingly in spec file.