### PR TITLE
Update selftest

### DIFF
--- a/testcases/smbtorture-test/selftest/README
+++ b/testcases/smbtorture-test/selftest/README
@@ -1,5 +1,5 @@
 Scripts and modules copied over from the samba source tree.
 
 At the time of copy, the samba head is at
-ddd8ae51f8c smb2_server: do async shutdown for pending multi-channel requests
+232054c09b1 lib/util: remove extra safe_string.h file
 

--- a/testcases/smbtorture-test/selftest/knownfail
+++ b/testcases/smbtorture-test/selftest/knownfail
@@ -83,11 +83,13 @@
 ^samba4.raw.rename.*.osxrename
 ^samba4.raw.rename.*.directory rename
 ^samba4.rpc.winreg.*security
-^samba4.local.registry.(dir|ldb).check hive security
-^samba4.local.registry.local.security
+^samba4.local.registry.*.(dir|ldb).check hive security
+^samba4.local.registry.*.local.security
 ^samba4.rpc.wkssvc
 ^samba4.rpc.handles.*.lsarpc-shared
-^samba4.rpc.epmapper
+^samba4.rpc.epmapper.*.Lookup_simple
+^samba4.rpc.epmapper.*.Map_simple
+^samba4.rpc.epmapper.*.Map_full
 ^samba4.rpc.lsalookup on ncalrpc
 ^samba4.rpc.lsalookup on ncacn_np
 ^samba4.rpc.lsalookup with seal,padcheck
@@ -158,7 +160,7 @@
 ^samba4.smb2.oplock.levelii500\(.*\)$ # samba 4 oplocks are a mess
 ^samba4.smb2.oplock.levelii502\(.*\)$ # samba 4 oplocks are a mess
 ^samba4.smb2.oplock.brl1\(.*\)$ # samba 4 oplocks are a mess
-^samba4.smb2.oplock.batch22\(.*\)$ # samba 4 oplocks are a mess
+^samba4.smb2.oplock.batch22.\(.*\)$ # samba 4 oplocks are a mess
 ^samba4.smb2.oplock.batch19\(.*\)$ # samba 4 oplocks are a mess
 ^samba4.smb2.oplock.batch12\(.*\)$ # samba 4 oplocks are a mess
 ^samba4.smb2.oplock.batch11\(.*\)$ # samba 4 oplocks are a mess
@@ -211,10 +213,11 @@
 ^samba3.smb2.session.*reauth5 # some special anonymous checks?
 ^samba3.smb2.compound.interim2 # wrong return code (STATUS_CANCELLED)
 ^samba3.smb2.compound.aio.interim2 # wrong return code (STATUS_CANCELLED)
-^samba3.smb2.replay.channel-sequence
-^samba3.smb2.replay.replay3
-^samba3.smb2.replay.replay4
-^samba3.smb2.lock.*replay
+^samba3.smb2.replay.replay3 # This requires multi-chanel
+^samba3.smb2.replay.replay4 # This requires multi-chanel
+^samba3.smb2.lock.replay_smb3_specification_multi # This requires multi-chanel
+^samba3.smb2.lock.replay_smb3_specification_durable\(nt4_dc\) # Requires durable handles
+^samba3.smb2.lock.*replay_broken_windows # This tests the windows behaviour
 ^samba3.smb2.lease.statopen3
 ^samba3.smb2.lease.unlink # we currently do not downgrade RH lease to R after unlink
 ^samba3.smb2.multichannel

--- a/testcases/smbtorture-test/selftest/knownfail.d/vlv
+++ b/testcases/smbtorture-test/selftest/knownfail.d/vlv
@@ -1,2 +1,2 @@
 samba4.ldap.vlv.python.*__main__.VLVTests.test_vlv_change_search_expr
-samba4.ldap.vlv.python.*__main__.PagedResultsTests.test_paged_cant_change_controls_data
+samba4.ldap.vlv.python.*__main__.PagedResultsTestsRW.test_paged_cant_change_controls_data

--- a/testcases/smbtorture-test/selftest/subunithelper.py
+++ b/testcases/smbtorture-test/selftest/subunithelper.py
@@ -26,7 +26,6 @@ from samba import subunit
 from samba.subunit.run import TestProtocolClient
 from samba.subunit import iso8601
 import unittest
-from samba.compat import binary_type
 
 
 VALID_RESULTS = set(['success', 'successful', 'failure', 'fail', 'skip',
@@ -93,7 +92,7 @@ def parse_results(msg_ops, statistics, fh):
                     else:
                         reason += l
 
-                if isinstance(reason, binary_type):
+                if isinstance(reason, bytes):
                     remote_error = subunit.RemoteError(reason.decode("utf-8"))
                 else:
                     remote_error = subunit.RemoteError(reason)


### PR DESCRIPTION
selftest: Update selftest files from latest samba sources
    
The python binary_type was taken off the samba python modules causing
issues in the selftest infrastructure in our tests.
    
We sync up with the latest changes to the selftest executables,
libraries and test list.
    
Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>
