### PR TITLE
Tests add support for multiple shares

### DIFF
--- a/testcases/consistency-test/consistency-check.py
+++ b/testcases/consistency-test/consistency-check.py
@@ -25,30 +25,42 @@ test_info = testhelper.read_yaml(test_info_file)
 tmp_root = testhelper.get_tmp_root()
 mount_point = testhelper.get_tmp_mount_point(tmp_root)
 mount_params = testhelper.get_default_mount_params(test_info)
-share = mount_params["share"]
 
 # First open the default share and write a file with contents
 # set to the test_string
 flag_share_mounted = 0
 flag_file_created = 0
 try:
-    testhelper.cifs_mount(mount_params, mount_point)
-    flag_share_mounted = 1
-    test_file = testhelper.get_tmp_file(mount_point)
-    flag_file_created = 1
-    with open(test_file, 'w') as f:
-        f.write(test_string)
-    testhelper.cifs_umount(mount_point)
-    flag_share_mounted = 0
-
-    for i in range(1, testhelper.get_total_mount_parameter_combinations(test_info)):
-        mount_params = testhelper.get_mount_parameter(test_info, share, i)
+    print("\n")
+    for sharenum in range(testhelper.get_num_shares(test_info)):
+        share = testhelper.get_share(test_info, sharenum)
+        mount_params["share"] = share
+        print("Testing %s" % (share))
         testhelper.cifs_mount(mount_params, mount_point)
         flag_share_mounted = 1
-        with open(test_file, 'r') as f:
-            assert file_content_check(f, test_string), "File content does not match"
+        test_file = testhelper.get_tmp_file(mount_point)
+        flag_file_created = 1
+        with open(test_file, 'w') as f:
+            f.write(test_string)
         testhelper.cifs_umount(mount_point)
         flag_share_mounted = 0
+
+        for i in range(1, testhelper.get_total_mount_parameter_combinations(test_info)):
+            mount_params = testhelper.get_mount_parameter(test_info, share, i)
+            testhelper.cifs_mount(mount_params, mount_point)
+            flag_share_mounted = 1
+            with open(test_file, 'r') as f:
+                assert file_content_check(f, test_string), "File content does not match"
+            testhelper.cifs_umount(mount_point)
+            flag_share_mounted = 0
+
+        if (flag_file_created == 1):
+            testhelper.cifs_mount(mount_params, mount_point)
+            flag_share_mounted = 1
+            os.unlink(test_file)
+            flag_file_created = 0
+            testhelper.cifs_umount(mount_point)
+            flag_share_mounted = 0
 
 except:
     print("Error while executing test")

--- a/testcases/mount-test/mount-test.py
+++ b/testcases/mount-test/mount-test.py
@@ -18,16 +18,24 @@ tmp_root = testhelper.get_tmp_root()
 mount_point = testhelper.get_tmp_mount_point(tmp_root)
 mount_params = testhelper.get_default_mount_params(test_info)
 
-
 flag_share_mounted = 0
 flag_file_created = 0
 try:
-    testhelper.cifs_mount(mount_params, mount_point)
-    flag_share_mounted = 1
-    test_file = testhelper.get_tmp_file(mount_point)
-    flag_file_created = 1
-    with open(test_file, 'w') as f:
-        f.write(test_string)
+    print("\n")
+    for i in range(testhelper.get_num_shares(test_info)):
+        mount_params["share"] = testhelper.get_share(test_info, i)
+        print("Testing //%s/%s" % (mount_params["host"],
+                                         mount_params["share"]))
+        testhelper.cifs_mount(mount_params, mount_point)
+        flag_share_mounted = 1
+        test_file = testhelper.get_tmp_file(mount_point)
+        flag_file_created = 1
+        with open(test_file, 'w') as f:
+            f.write(test_string)
+        os.unlink(test_file)
+        flag_file_created = 0
+        testhelper.cifs_umount(mount_point)
+        flag_share_mounted = 0
 except:
     print("Error while executing test")
     raise

--- a/testcases/smbtorture-test/selftest/flapping.gluster
+++ b/testcases/smbtorture-test/selftest/flapping.gluster
@@ -1,0 +1,2 @@
+# https://bugzilla.samba.org/show_bug.cgi?id=14486
+^samba3.smb2.rw.rw1

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -56,7 +56,6 @@ smbtorture_tests_info_file = sys.argv[2]
 with open(smbtorture_tests_info_file) as f:
     smbtorture_info = yaml.safe_load(f)
 
-#First the expected pass tests
 print("")
 for torture_test in smbtorture_info:
     print("\t{:<20}".format(torture_test)),

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -30,6 +30,7 @@ def smbtorture(mount_params, test, output):
     filter_subunit_filters = filter_subunit_filters + " --expected-failures=" + script_root + "/selftest/knownfail.d"
     filter_subunit_filters = filter_subunit_filters + " --flapping=" + script_root + "/selftest/flapping"
     filter_subunit_filters = filter_subunit_filters + " --flapping=" + script_root + "/selftest/flapping.d"
+    filter_subunit_filters = filter_subunit_filters + " --flapping=" + script_root + "/selftest/flapping.gluster"
     filter_subunit_cmd = "%s %s %s" % (filter_subunit_exec, filter_subunit_options_str, filter_subunit_filters)
 
     format_subunit_cmd = "%s --immediate" % (format_subunit_exec)

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -57,14 +57,17 @@ smbtorture_tests_info_file = sys.argv[2]
 with open(smbtorture_tests_info_file) as f:
     smbtorture_info = yaml.safe_load(f)
 
-print("")
-for torture_test in smbtorture_info:
-    print("\t{:<20}".format(torture_test)),
-    ret = smbtorture(mount_params, torture_test, output)
-    if (ret == False):
-        print("{:>10}".format("[Failed]"))
-        print("\n")
-        with open(output) as f:
-            print(f.read())
-        assert False
-    print("{:>10}".format("[OK]"))
+for sharenum in range(testhelper.get_num_shares(test_info)):
+    mount_params["share"] = testhelper.get_share(test_info, sharenum)
+    print("")
+    print("share: %s" % (mount_params["share"]))
+    for torture_test in smbtorture_info:
+        print("\t{:<20}".format(torture_test)),
+        ret = smbtorture(mount_params, torture_test, output)
+        if (ret == False):
+            print("{:>10}".format("[Failed]"))
+            print("\n")
+            with open(output) as f:
+                print(f.read())
+            assert False
+        print("{:>10}".format("[OK]"))

--- a/testhelper/testhelper.py
+++ b/testhelper/testhelper.py
@@ -80,3 +80,25 @@ def get_mount_parameter(test_info, share, combonum):
         test_info["test_users"][num_users]["password"]
     )
 
+def get_num_shares(test_info):
+    """ Get number of exported shares
+
+    Parameters:
+    test_info: Dict containing the parsed yml file.
+
+    Returns:
+    int: number of exported shares
+    """
+    return len(test_info["exported_sharenames"])
+
+def get_share(test_info, share_num):
+    """ Get exported share name
+
+    Parameters:
+    test_info: Dict containing the parsed yml file.
+    share_num: The index within the exported sharenames list
+
+    Returns:
+    str: exported sharename in index share_num
+    """
+    return test_info["exported_sharenames"][share_num]


### PR DESCRIPTION
Modify the tests to also test against the new disperse volumes.

We add a new flapping.gluster for smbtorture tests which do not pass against the current version of the samba-gluster setup.