### PR TITLE
Build fixes

### DIFF
--- a/packaging/samba.spec.j2
+++ b/packaging/samba.spec.j2
@@ -1604,7 +1604,6 @@ fi
 %{_libdir}/samba/libsmb-transport-samba4.so
 %{_libdir}/samba/libsmbclient-raw-samba4.so
 %{_libdir}/samba/libsmbd-base-samba4.so
-%{_libdir}/samba/libsmbd-conn-samba4.so
 %{_libdir}/samba/libsmbd-shim-samba4.so
 %{_libdir}/samba/libsmbldaphelper-samba4.so
 %{_libdir}/samba/libsys-rw-samba4.so
@@ -2092,7 +2091,6 @@ fi
 %{python3_sitearch}/samba/__pycache__/auth_util.*.pyc
 %{python3_sitearch}/samba/__pycache__/colour.*.pyc
 %{python3_sitearch}/samba/__pycache__/common.*.pyc
-%{python3_sitearch}/samba/__pycache__/compat.*.pyc
 %{python3_sitearch}/samba/__pycache__/dbchecker.*.pyc
 %{python3_sitearch}/samba/__pycache__/descriptor.*.pyc
 %{python3_sitearch}/samba/__pycache__/drs_utils.*.pyc
@@ -2128,7 +2126,6 @@ fi
 %{python3_sitearch}/samba/dbchecker.py
 %{python3_sitearch}/samba/colour.py
 %{python3_sitearch}/samba/common.py
-%{python3_sitearch}/samba/compat.py
 %{python3_sitearch}/samba/credentials.*.so
 %{python3_sitearch}/samba/crypto.*.so
 %dir %{python3_sitearch}/samba/dcerpc


### PR DESCRIPTION
Following were removed recently in upstream:
* [libsmbd-conn-samba4.so](https://git.samba.org/?p=samba.git;a=commit;h=80ac7fa7c4c728bef4f947872c090fec35fb26f0)
* [compat.py](https://git.samba.org/?p=samba.git;a=commit;h=a3cd31532125ccb537af6cd9d27c761b7da4b03a)