### PR TITLE
Add successful smb2 tests

### DIFF
--- a/testcases/smbtorture-test/selftest/filter-subunit
+++ b/testcases/smbtorture-test/selftest/filter-subunit
@@ -102,12 +102,8 @@ else:
                                       flapping=flapping)
 
 try:
-    from samba.compat import PY3
     from io import TextIOWrapper as TextIOWrapper
-    if PY3:
-        forgiving_stdin = TextIOWrapper(sys.stdin.buffer, errors='ignore',  encoding='utf-8')
-    else:
-        forgiving_stdin = sys.stdin
+    forgiving_stdin = TextIOWrapper(sys.stdin.buffer, errors='ignore',  encoding='utf-8')
     ret = subunithelper.parse_results(msg_ops, statistics, forgiving_stdin)
 except subunithelper.ImmediateFail:
     sys.stdout.flush()

--- a/testcases/smbtorture-test/selftest/flapping.gluster
+++ b/testcases/smbtorture-test/selftest/flapping.gluster
@@ -1,2 +1,0 @@
-# https://bugzilla.samba.org/show_bug.cgi?id=14486
-^samba3.smb2.rw.rw1

--- a/testcases/smbtorture-test/smbtorture-tests-info.yml
+++ b/testcases/smbtorture-test/smbtorture-tests-info.yml
@@ -1,3 +1,24 @@
 ---
 - smb2.rw
 - smb2.read
+- smb2.bench-oplock
+- smb2.check-sharemode
+- smb2.compound_find
+- smb2.connect
+- smb2.credits
+- smb2.deny
+- smb2.lock
+- smb2.mangle
+- smb2.maximum_allowed
+- smb2.mkdir
+- smb2.multichannel
+- smb2.notify-inotify
+- smb2.rename
+- smb2.replay
+- smb2.sdread
+- smb2.secleak
+- smb2.session-id
+- smb2.sharemode
+- smb2.tcon
+- smb2.twrp
+- smb2.winattr


### PR DESCRIPTION
The patch series contains an additional patch 
"Update filter-subunit"
Which has its own pull request. It is however necessary for this patch series and hence included.

We clean up flapping.gluster list to clear off the smb2.rw.rw1 test which has now been fixed on both gluster and samba.
We also add tests which are known to run successfully against the gluster volumes to the test list.