### PR TITLE
Add tests which fail with performance.cache-samba-metadata on

### DIFF
--- a/testcases/smbtorture-test/selftest/flapping.gluster
+++ b/testcases/smbtorture-test/selftest/flapping.gluster
@@ -1,0 +1,6 @@
+#https://github.com/gluster/samba-integration/issues/118
+^samba3.smb2.durable-open-disconnect.open-oplock-disconnect
+^samba3.smb2.openattr
+^samba3.smb2.session.*
+^samba3.smb2.create.aclfile
+

--- a/testcases/smbtorture-test/smbtorture-tests-info.yml
+++ b/testcases/smbtorture-test/smbtorture-tests-info.yml
@@ -22,3 +22,7 @@
 - smb2.tcon
 - smb2.twrp
 - smb2.winattr
+- smb2.durable-open-disconnect
+- smb2.openattr
+- smb2.session
+- smb2.create


### PR DESCRIPTION
These tests fail when performance.cache-samba-metadata is enabled.

We use the flapping.gluster list to get the test suite to ignore the results of these failing tests. We will update the flapping list once the issues have been resolved.