### PR TITLE
Fix GlusterFS nightly builds repository link

### DIFF
--- a/ansible/roles/prep.dirs/files/glusterfs-nightly-repo.tpl
+++ b/ansible/roles/prep.dirs/files/glusterfs-nightly-repo.tpl
@@ -2,7 +2,7 @@ config_opts['yum.conf'] += """
 
 [gluster-nightly-master]
 name=Gluster Nightly builds (master branch)
-baseurl=http://artifacts.ci.centos.org/gluster/nightly/master/$releasever/$basearch
+baseurl=http://artifacts.ci.centos.org/gluster/nightly/devel/$releasever/$basearch
 enabled=1
 gpgcheck=0
 """


### PR DESCRIPTION
GlusterFS upstream default branch name was renamed to _devel_ recently.