### PR TITLE
Install glusterfs-geo-replication which is needed for the nightly builds

### DIFF
--- a/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
@@ -4,6 +4,12 @@
 - name: Enable firewall rules for gluster
   firewalld: service=glusterfs permanent=yes state=enabled
 
+# https://github.com/gluster/samba-integration/issues/123
+- name: Install glusterfs-geo-replication package.
+  yum:
+    name: glusterfs-geo-replication
+    state: latest
+
 - name: Ensure glusterd service is enabled
   service: name=glusterd state=started enabled=yes
 


### PR DESCRIPTION
There appears to be a bug in the nightly glusterfs builds where glusterd
would not start without the executable /usr/libexec/glusterfs/gsyncd
provided by glusterfs-geo-replication. This package isn't automatically
installed.

More information at
https://github.com/gluster/samba-integration/issues/123

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>