### PR TITLE
Improve output logging for the tests run

### DIFF
--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -66,8 +66,10 @@ for sharenum in range(testhelper.get_num_shares(test_info)):
         ret = smbtorture(mount_params, torture_test, output)
         if (ret == False):
             print("{:>10}".format("[Failed]"))
-            print("\n")
+            print("\n\n")
+            print("--Output Start--")
             with open(output) as f:
                 print(f.read())
+            print("--Output End--")
             assert False
         print("{:>10}".format("[OK]"))

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -35,11 +35,11 @@ def smbtorture(mount_params, test, output):
 
     format_subunit_cmd = "%s --immediate" % (format_subunit_exec)
 
-    cmd = "%s|%s|%s > %s" % (
+    cmd = "%s|%s|/usr/bin/tee %s|%s >/dev/null" % (
                                 smbtorture_cmd,
                                 filter_subunit_cmd,
+                                output,
                                 format_subunit_exec,
-                                output
                             )
     ret = os.system(cmd)
     return ret == 0

--- a/testcases/smbtorture-test/smbtorture-test.py
+++ b/testcases/smbtorture-test/smbtorture-test.py
@@ -35,12 +35,16 @@ def smbtorture(mount_params, test, output):
 
     format_subunit_cmd = "%s --immediate" % (format_subunit_exec)
 
-    cmd = "%s|%s|/usr/bin/tee %s|%s >/dev/null" % (
+    cmd = "%s|%s|/usr/bin/tee -a %s|%s >/dev/null" % (
                                 smbtorture_cmd,
                                 filter_subunit_cmd,
                                 output,
                                 format_subunit_exec,
                             )
+
+    with open(output, 'w') as f:
+        f.write("Command: " + cmd + "\n\n")
+
     ret = os.system(cmd)
     return ret == 0
 


### PR DESCRIPTION
 The output logs at the moment only log content filtered through the format_subunit script. This isn't very clear about the exact cause for failure. These changes fix this.