### PR TITLE
samba-build: fix test-install of centos8 rpms

### DIFF
--- a/packaging/samba.spec.j2
+++ b/packaging/samba.spec.j2
@@ -1634,7 +1634,7 @@ fi
 
 %{_libdir}/samba/libtalloc.so.*
 %{_libdir}/samba/libpytalloc-util.*.so.*
-%{_mandir}/man3/talloc.3.gz
+%exclude %{_mandir}/man3/talloc.3.gz
 %{python3_sitearch}/talloc.*.so*
 
 %{_libdir}/samba/libtevent.so.*
@@ -1649,7 +1649,7 @@ fi
 
 %{_libdir}/samba/libldb.so.*
 %{_libdir}/samba/libpyldb-util.*.so.*
-%{_mandir}/man3/ldb.3.gz
+%exclude %{_mandir}/man3/ldb.3.gz
 %{python3_sitearch}/__pycache__/_ldb_text.*.pyc
 %{python3_sitearch}/_ldb_text.py*
 %{python3_sitearch}/ldb.*.so


### PR DESCRIPTION
the talloc and ldb manpages installed witht the client-libs package
conflict with the same files from libtalloc-devel and libldb-devel
respectively.

Fix this by not packaging the manages in our RPMs at all.

Signed-off-by: Michael Adam <obnox@samba.org>