### PR TITLE
Prepare playbooks for multi distribution support 

### DIFF
--- a/vagrant/ansible/client-test.yml
+++ b/vagrant/ansible/client-test.yml
@@ -2,6 +2,7 @@
   become: yes
   become_method: sudo
   vars_files:
+    - distro-vars.yml
     - cluster-vars.yml
   roles:
     - client.test.prep

--- a/vagrant/ansible/roles/client.prep/tasks/centos7.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/centos7.yml
@@ -1,0 +1,16 @@
+- name: Install required packages
+  yum:
+    name:
+      - glusterfs-fuse
+      - cifs-utils
+      - samba-test
+      - python-pip
+      - git
+    state: latest
+
+- name: Install Python 3 modules
+  pip:
+    executable: /usr/bin/pip3
+    name:
+      - PyYAML
+      - iso8601

--- a/vagrant/ansible/roles/client.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/main.yml
@@ -1,19 +1,6 @@
-- name: Install required packages
-  yum:
-    name:
-      - glusterfs-fuse
-      - cifs-utils
-      - samba-test
-      - python-pip
-      - git
-    state: latest
-
-- name: Install Python 3 modules
-  pip:
-    executable: /usr/bin/pip3
-    name:
-      - PyYAML
-      - iso8601
+- name: Run distro specific tasks for client.prep
+  include_tasks:
+    file: "{{ distro.actions_file }}"
 
 - debug:
     msg: "{{ ctdb_network_public_interfaces }}"

--- a/vagrant/ansible/roles/common.prep/tasks/centos7.yml
+++ b/vagrant/ansible/roles/common.prep/tasks/centos7.yml
@@ -1,0 +1,30 @@
+- name: Perform a complete update
+  yum:
+    name: '*'
+    state: latest
+
+- name: Enable EPEL repository
+  yum:
+    name: epel-release
+    state: latest
+
+- name: Enable GlusterFS nightly rpms repository
+  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
+
+# add copr to get compat-gnutls34 (needed for centos 7)
+- name: Install yum copr plugin
+  yum:
+    name: yum-plugin-copr
+    state: latest
+
+- name: add copr to get compat-gnutls34
+  command: yum -y copr enable sergiomb/SambaAD
+
+- name: modify copr repo to only use it for compat-gnutls packages
+  lineinfile:
+    dest: /etc/yum.repos.d/_copr_sergiomb-SambaAD.repo
+    line: "includepkgs=compat-gnutls34.* compat-nettle32.*"
+    insertafter: '\[copr:copr.fedorainfracloud.org:sergiomb:SambaAD\]'
+
+- name: Enable Samba nightly rpms repository
+  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly-samba/samba-nightly-master.repo

--- a/vagrant/ansible/roles/common.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/common.prep/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Run distro specific tasks
+  include_tasks:
+    file: "{{ distro.actions_file }}"
+
 - name: create ansible directory (for ssh key)
   file:
     path: /home/vagrant/ansible
@@ -17,38 +21,3 @@
   copy:
     src: etc-hosts
     dest: /etc/hosts
-
-- name: Perform a complete update
-  yum:
-    name: '*'
-    state: latest
-
-- name: Enable EPEL repository
-  yum:
-    name: epel-release
-    state: latest
-
-- name: Enable GlusterFS nightly rpms repository
-  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
-
-- name: add copr to get compat-gnutls34 (needed for centos 7)
-  block:
-
-    - name: Install yum copr plugin
-      yum:
-        name: yum-plugin-copr
-        state: latest
-
-    - name: add copr to get compat-gnutls34
-      command: yum -y copr enable sergiomb/SambaAD
-
-    - name: modify copr repo to only use it for compat-gnutls packages
-      lineinfile:
-        dest: /etc/yum.repos.d/_copr_sergiomb-SambaAD.repo
-        line: "includepkgs=compat-gnutls34.* compat-nettle32.*"
-        insertafter: '\[copr:copr.fedorainfracloud.org:sergiomb:SambaAD\]'
-
-  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
-
-- name: Enable Samba nightly rpms repository
-  command: yum-config-manager --add-repo http://artifacts.ci.centos.org/gluster/nightly-samba/samba-nightly-master.repo

--- a/vagrant/ansible/roles/ctdb.setup/tasks/centos7.yml
+++ b/vagrant/ansible/roles/ctdb.setup/tasks/centos7.yml
@@ -1,0 +1,13 @@
+- name: Add ctdb package
+  yum:
+    name: ctdb
+    state: present
+
+- name: Install libsemanage-python. This is needed for the seboolean ansible command
+  yum: name=libsemanage-python state=present
+
+- name: SELinux - Allow CTDB to access recovery lockfile from FUSE mount
+  seboolean:
+    name: use_fusefs_home_dirs
+    state: yes
+    persistent: yes

--- a/vagrant/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/ctdb.setup/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Run distro specific tasks for ctdb.setup
+  include_tasks:
+    file: "{{ distro.actions_file }}"
+
 - name: Check for required variables
   block:
     - fail:
@@ -37,11 +41,6 @@
     opts: '_netdev,transport=tcp,xlator-option=*client*.ping-timeout=10'
     state: mounted
 
-- name: Add ctdb package
-  yum:
-    name: ctdb
-    state: present
-
 - name: Add ctdb rules to firewalld
   firewalld:
     service: ctdb
@@ -54,15 +53,6 @@
     line: "\trecovery lock = /gluster/lock/recovery.lock"
     regexp: "recovery lock"
     insertafter: '\[cluster\]'
-
-- name: Install libsemanage-python. This is needed for the seboolean ansible command
-  yum: name=libsemanage-python state=present
-
-- name: SELinux - Allow CTDB to access recovery lockfile from FUSE mount
-  seboolean:
-    name: use_fusefs_home_dirs
-    state: yes
-    persistent: yes
 
 - name: Enable check consistency of databases during startup
   command: '/bin/ctdb event script enable legacy 00.ctdb'

--- a/vagrant/ansible/roles/glusterfs.setup/tasks/centos7.yml
+++ b/vagrant/ansible/roles/glusterfs.setup/tasks/centos7.yml
@@ -1,0 +1,5 @@
+# https://github.com/gluster/samba-integration/issues/123
+- name: Install glusterfs-geo-replication package.
+  yum:
+    name: glusterfs-geo-replication
+    state: latest

--- a/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
@@ -1,14 +1,12 @@
+- name: Run distro specific tasks for glusterfs.setup
+  include_tasks:
+    file: "{{ distro.actions_file }}"
+
 - include_role:
     name: gluster.infra
 
 - name: Enable firewall rules for gluster
   firewalld: service=glusterfs permanent=yes state=enabled
-
-# https://github.com/gluster/samba-integration/issues/123
-- name: Install glusterfs-geo-replication package.
-  yum:
-    name: glusterfs-geo-replication
-    state: latest
 
 - name: Ensure glusterd service is enabled
   service: name=glusterd state=started enabled=yes

--- a/vagrant/ansible/roles/node.prep/tasks/centos7.yml
+++ b/vagrant/ansible/roles/node.prep/tasks/centos7.yml
@@ -1,0 +1,18 @@
+- name: Install GlusterFS rpms
+  yum:
+    name: "{{ gluster_rpms }}"
+    state: latest
+  vars:
+    gluster_rpms:
+      - glusterfs-server
+
+- name: Install basic tools
+  yum:
+   name: "{{ tools }}"
+   state: latest
+  vars:
+    tools:
+      - lvm2
+      - firewalld
+      - libselinux-python
+

--- a/vagrant/ansible/roles/node.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/node.prep/tasks/main.yml
@@ -1,18 +1,3 @@
-- name: Install GlusterFS rpms
-  yum:
-    name: "{{ gluster_rpms }}"
-    state: latest
-  vars:
-    gluster_rpms:
-      - glusterfs-server
-
-- name: Install basic tools
-  yum:
-   name: "{{ tools }}"
-   state: latest
-  vars:
-    tools:
-      - lvm2
-      - firewalld
-      - libselinux-python
-
+- name: Run distro specific tasks for node.prep
+  include_tasks:
+    file: "{{ distro.actions_file }}"

--- a/vagrant/ansible/roles/samba-glusterfs.setup/tasks/centos7.yml
+++ b/vagrant/ansible/roles/samba-glusterfs.setup/tasks/centos7.yml
@@ -1,0 +1,16 @@
+---
+- name: Install samba and samba-vfs-glusterfs packages
+  yum:
+    name:
+      - samba
+      - samba-vfs-glusterfs
+    state: present
+
+- name: Install libsemanage-python. This is needed for the seboolean ansible command
+  yum: name=libsemanage-python state=present
+
+- name: Selinux - Allow Samba to access glusterfs services
+  seboolean:
+    name: samba_load_libgfapi
+    state: yes
+    persistent: yes

--- a/vagrant/ansible/roles/samba-glusterfs.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/samba-glusterfs.setup/tasks/main.yml
@@ -1,25 +1,13 @@
 ---
-- name: Install samba and samba-vfs-glusterfs packages
-  yum:
-    name:
-      - samba
-      - samba-vfs-glusterfs
-    state: present
+- name: Run distro specific tasks for samba-glusterfs.setup
+  include_tasks:
+    file: "{{ distro.actions_file }}"
 
 - name: Enable firewall for samba
   firewalld:
     service: samba
     permanent: yes
     state: enabled
-
-- name: Install libsemanage-python. This is needed for the seboolean ansible command
-  yum: name=libsemanage-python state=present
-
-- name: Selinux - Allow Samba to access glusterfs services
-  seboolean:
-    name: samba_load_libgfapi
-    state: yes
-    persistent: yes
 
 - name: Create fresh directory /etc/samba/smb.shares to contain share definition
   block:

--- a/vagrant/ansible/setup-clients.yml
+++ b/vagrant/ansible/setup-clients.yml
@@ -2,6 +2,7 @@
   become: yes
   become_method: sudo
   vars_files:
+    - distro-vars.yml
     - cluster-vars.yml
   roles:
     - common.prep

--- a/vagrant/ansible/setup-cluster.yml
+++ b/vagrant/ansible/setup-cluster.yml
@@ -2,6 +2,7 @@
   become: yes
   become_method: sudo
   vars_files:
+    - distro-vars.yml
     - cluster-vars.yml
   roles:
     - common.prep

--- a/vagrant/hosts.update.yml
+++ b/vagrant/hosts.update.yml
@@ -4,8 +4,7 @@
 - hosts: all
   become: yes
   become_method: sudo
-  tasks:
-    - name: Perform a complete update
-      yum:
-        name: '*'
-        state: latest
+  vars_files:
+    - ansible/distro-vars.yml
+  roles:
+    - hosts.update

--- a/vagrant/local.yml
+++ b/vagrant/local.yml
@@ -2,5 +2,6 @@
   connection: local
   become: no
   roles:
+    - local.defaults
     - local.vagrant
     - local.prep

--- a/vagrant/roles/hosts.update/tasks/centos7.yml
+++ b/vagrant/roles/hosts.update/tasks/centos7.yml
@@ -1,0 +1,5 @@
+- name: Perform a complete update
+  yum:
+    name: '*'
+    state: latest
+

--- a/vagrant/roles/hosts.update/tasks/main.yml
+++ b/vagrant/roles/hosts.update/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Run distro specific tasks for host.update
+  include_tasks:
+    file: "{{ distro.actions_file }}"

--- a/vagrant/roles/local.defaults/tasks/centos7.yml
+++ b/vagrant/roles/local.defaults/tasks/centos7.yml
@@ -1,0 +1,2 @@
+vagrant_image: "centos/7"
+actions_file: "centos7.yml"

--- a/vagrant/roles/local.defaults/tasks/main.yml
+++ b/vagrant/roles/local.defaults/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- set_fact:
+    use_distro: "centos7"
+  when: use_distro is undefined
+
+- name: Import distro specific defaults
+  include_vars:
+    file: "{{ use_distro }}.yml"
+    name: distro
+
+- debug:
+    var: distro

--- a/vagrant/roles/local.prep/tasks/main.yml
+++ b/vagrant/roles/local.prep/tasks/main.yml
@@ -1,3 +1,12 @@
+- name: Generate distro-vars.yml in ansible directory
+  block:
+    - set_fact:
+        t:
+          distro: "{{ distro }}"
+    - copy:
+        content: '{{ t| to_nice_yaml }}'
+        dest: ./ansible/distro-vars.yml
+
 - name: copy vagrant generated inventory file - local machine
   copy:
     src: .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory

--- a/vagrant/roles/local.vagrant/tasks/main.yml
+++ b/vagrant/roles/local.vagrant/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Setup Vagrant file
+  template:
+    src: Vagrantfile.j2
+    dest: Vagrantfile
+
 - name: start vagrant vms
   command: vagrant up --no-provision
 

--- a/vagrant/roles/setup.prep/tasks/centos7.yml
+++ b/vagrant/roles/setup.prep/tasks/centos7.yml
@@ -1,0 +1,35 @@
+- name: update packages
+  yum:
+    name: '*'
+    state: latest
+
+- name: Enable EPEL repository
+  yum:
+    name: epel-release
+    state: latest
+
+- name: Install Python2 pip
+  yum:
+    name: python2-pip
+    state: installed
+
+- name: Install pip jinja2 library
+  pip:
+    name: jinja2
+    state: latest
+
+- name: add copr to get gluster-ansible from sac
+  block:
+
+    - name: Install yum copr plugin
+      yum:
+        name: yum-plugin-copr
+        state: latest
+
+    - name: add copr to get gluster-ansible
+      command: yum -y copr enable sac/gluster-ansible
+
+- name: Install gluster-ansible
+  yum:
+    name: "gluster-ansible"
+    state: latest

--- a/vagrant/roles/setup.prep/tasks/main.yml
+++ b/vagrant/roles/setup.prep/tasks/main.yml
@@ -1,38 +1,6 @@
-- name: update packages
-  yum:
-    name: '*'
-    state: latest
-
-- name: Enable EPEL repository
-  yum:
-    name: epel-release
-    state: latest
-
-- name: Install Python2 pip
-  yum:
-    name: python2-pip
-    state: installed
-
-- name: Install pip jinja2 library
-  pip:
-    name: jinja2
-    state: latest
-
-- name: add copr to get gluster-ansible from sac
-  block:
-
-    - name: Install yum copr plugin
-      yum:
-        name: yum-plugin-copr
-        state: latest
-
-    - name: add copr to get gluster-ansible
-      command: yum -y copr enable sac/gluster-ansible
-
-- name: Install gluster-ansible
-  yum:
-    name: "gluster-ansible"
-    state: latest
+- name: Run distro specific tasks for setup.prep
+  include_tasks:
+    file: "{{ distro.actions_file }}"
 
 - name: copy ansible playbooks to setup machine
   synchronize:

--- a/vagrant/setup.prep.yml
+++ b/vagrant/setup.prep.yml
@@ -4,5 +4,7 @@
 - hosts: setup
   become: yes
   become_method: sudo
+  vars_files:
+    - ansible/distro-vars.yml
   roles:
     - setup.prep

--- a/vagrant/templates/Vagrantfile.j2
+++ b/vagrant/templates/Vagrantfile.j2
@@ -16,7 +16,7 @@ CLIENT_IP = "#{PUBLIC_NETWORK_BASE}.5"
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
     config.vm.provider :libvirt do |v,override|
-        override.vm.box = "centos/7"
+      override.vm.box = "{{ distro.vagrant_image }}"
         override.vm.synced_folder '.', '/vagrant', disabled: true
 
         # We can not use qemu_use_session universally.


### PR DESCRIPTION
The playbooks as setup is only suitable for testing the samba-glusterfs setup using CentOS7. We cannot make simple changes to the playbook to add more distributions because
1) The package name varies. eg: libselinux-python, python-pip in CentOS7 vs python3-libsemanage, python3-pip in CentOS8
2) Differences in the base vagrant images, may mean additional steps may be required to have a working setup.
3) The commands used may be different between distributions.

To avoid lots of conditional statements which could be difficult to maintain, I've split up the actions specific to distributions into their own yaml files. This seems to be an easy approach which can then be improved incrementally to make it easier to modify further in the future.

We use two variables 
    vagrant_image, which is used to specify the image to be used by Vagrant and
    distro_specific actions, which indicate the yaml file to include for
    distribution specific actions.
These can be set as runtime variables and are set to default to centos 7 as used corrently in  the vagrant/roles/local.defaults.
An ansible/distro-vars.yml file is created and included in subsequent playbooks to implement the distro specific actions.

Sachin Prabhu
