### PR TITLE
tests: Add knownfail entries for several smb2.replay tests

### DIFF
--- a/testcases/smbtorture-test/selftest/knownfail.d/smb2.replay
+++ b/testcases/smbtorture-test/selftest/knownfail.d/smb2.replay
@@ -1,0 +1,23 @@
+# These tests demonstrate the broken Windows behavior
+# and check for ACCESS_DENIED instead of FILE_NOT_AVAILABLE
+# See https://bugzilla.samba.org/show_bug.cgi?id=14449
+^samba3.smb2.replay.dhv2-pending1l-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending1l-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending1n-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending1n-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+^samba3.smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
+^samba3.smb2.replay.dhv2-pending1o-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending1o-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending2l-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending2l-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending2n-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending2n-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending2o-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending2o-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending3l-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending3l-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending3n-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending3n-vs-oplock-windows
+^samba3.smb2.replay.dhv2-pending3o-vs-lease-windows
+^samba3.smb2.replay.dhv2-pending3o-vs-oplock-windows


### PR DESCRIPTION
Copy over the file
selftest/knownfail.d/smb2.replay
from the samba sources to our tests.

These tests were added to demonstrate bugs in the windows behaviour.
Please check commit
f5168a21abd s4:torture/smb2: add smb2.replay.dhv2-pending* tests

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>