### PR TITLE
Use CentOS 8 as default

### DIFF
--- a/vagrant/roles/local.defaults/tasks/main.yml
+++ b/vagrant/roles/local.defaults/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    use_distro: "centos7"
+    use_distro: "centos8"
   when: use_distro is undefined
 
 - name: Import distro specific defaults


### PR DESCRIPTION
Use CentOS 8 for the created vms.

This PR will provide us with a way to test if CentOS8 default is working properly in the CI environment.