### PR TITLE
Add reports

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -32,10 +32,13 @@ setup.cluster: setup.prep setup.test.only setup.cluster.only
 setup.clients:
 	@$(VSSH) setup "${SSH_EXTRA_VARS} make -C /home/vagrant/ansible setup.clients"
 
+generate.report:
+	@$(VSSH) setup "${SSH_EXTRA_VARS} make -C /home/vagrant/ansible generate.report"
+
 client.test:
 	@$(VSSH) setup "${SSH_EXTRA_VARS} make -C /home/vagrant/ansible client.test"
 
-setup.site: setup.cluster setup.clients client.test
+setup.site: setup.cluster setup.clients generate.report client.test
 
 client1.test:
 	@$(VSSH) client1 "sudo make -C /root/samba-integration-tests test"

--- a/vagrant/ansible/Makefile
+++ b/vagrant/ansible/Makefile
@@ -13,6 +13,9 @@ setup.cluster:
 setup.clients:
 	@ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./setup-clients.yml
 
+generate.report:
+	@ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./generate-report.yml
+
 client.test:
 	@ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./client-test.yml
 

--- a/vagrant/ansible/generate-report.yml
+++ b/vagrant/ansible/generate-report.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: yes
+  roles:
+    - report.versions

--- a/vagrant/ansible/roles/report.versions/tasks/main.yml
+++ b/vagrant/ansible/roles/report.versions/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- debug:
+    msg: "{{ item }} {{ ansible_facts.packages[item][0].version }}-{{ ansible_facts.packages[item][0].release }}"
+  when: ansible_facts.packages[item] is defined
+  loop:
+    - kernel
+    - samba-client
+    - samba
+    - ctdb
+    - glusterfs


### PR DESCRIPTION
Add an option to print out reports from the installed vms before running
tests. With this commit, we print out the package versions on the vms.
This is a very helpful data to log in the output with the results of the
test.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>