### PR TITLE
Update Fedora install docs

### DIFF
--- a/docs/Fedora-Setup.md
+++ b/docs/Fedora-Setup.md
@@ -8,11 +8,6 @@ Modify the steps accordingly for your setup.
 Ensure the following packages are installed
 > $ sudo dnf install qemu-kvm qemu-img git vagrant vagrant-libvirt ansible make libvirt-client
 
-Download and cache vagrant centos7 image.
-```
-$ vagrant box add "https://vagrantcloud.com/centos/7" --provider "libvirt"
-```
-
 For Fedora 33, we have to enable the use_session variable for vagrant libvirt vms to run properly. To do this, create a file ~/.vagrant.d/Vagrantfile with the following content
 ```
 Vagrant.configure("2") do |config|
@@ -33,10 +28,12 @@ $ cd samba-integration/
 $ make
 ```
 
-To run the CentOS8 version of test vms
+The first run will take longer than usual as Vagrant downloads the CentOS8 image from its repository. Subsequent runs will use the image from cache and the setup will be quicker.
+
+To run the CentOS7 version of test vms
 ```
 $ cd samba-integration/
-$ EXTRA_VARS="use_distro=centos8" make
+$ EXTRA_VARS="use_distro=centos7" make
 ```
 
 If you encounter failures bringing up the vagrant vms, you can check for more details by switching into the vagrant directory and manually bring up the machine.
@@ -44,13 +41,13 @@ If you encounter failures bringing up the vagrant vms, you can check for more de
 $ cd samba-integration/vagrant
 $ vagrant up
 ```
-Clean up with a 'vagrant destroy -f' command when done.
+Clean up with a 'make clean' command when done.
 
 The most common fault seen is because of the location of the default storage pool which could lead to permission issues. In this case, edit the default storage pool and switch to a directory which can be accessed by your user.
 
-Before you can reinstall the cluster setup, you will want to clear up the existing machines. To do this, we will need to use the vagrant command to destroy the created vms.
+Before you can reinstall the cluster setup, you will want to clear up the existing machines.
 ```
-$ cd samba-integration/vagrant
-$ vagrant destroy -f
+$ cd samba-integration/
+$ make clean
 ```
-This clears up all the vms created by the tool and the system is ready for a rebuild
+This clears up all the vms and temporary files created by the tool and the system is ready for a rebuild


### PR DESCRIPTION
Update to reflect the change in default to CentOs 8 and the introduction
of the make clean target to clear the old setup.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>