### PR TITLE
Update master spec file: library removal, new ctdb utility etc..

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2197,44 +2197,38 @@ fi
 
 %files -n python3-%{name}-test
 %dir %{python3_sitearch}/samba/tests
-%{python3_sitearch}/samba/tests/__init__.py
+%{python3_sitearch}/samba/tests/*.py
 %dir %{python3_sitearch}/samba/tests/__pycache__
 %{python3_sitearch}/samba/tests/__pycache__/*.*.pyc
-%{python3_sitearch}/samba/tests/*.py
 
 %dir %{python3_sitearch}/samba/tests/blackbox
-%{python3_sitearch}/samba/tests/blackbox/__init__.py
+%{python3_sitearch}/samba/tests/blackbox/*.py
 %dir %{python3_sitearch}/samba/tests/blackbox/__pycache__
 %{python3_sitearch}/samba/tests/blackbox/__pycache__/*.*.pyc
-%{python3_sitearch}/samba/tests/blackbox/*.py
 
 %dir %{python3_sitearch}/samba/tests/dcerpc
-%{python3_sitearch}/samba/tests/dcerpc/__init__.py
+%{python3_sitearch}/samba/tests/dcerpc/*.py
 %dir %{python3_sitearch}/samba/tests/dcerpc/__pycache__
 %{python3_sitearch}/samba/tests/dcerpc/__pycache__/*.*.pyc
-%{python3_sitearch}/samba/tests/dcerpc/*.py
 
 %dir %{python3_sitearch}/samba/tests/dns_forwarder_helpers
 %{python3_sitearch}/samba/tests/dns_forwarder_helpers/__pycache__/*.*.pyc
 %{python3_sitearch}/samba/tests/dns_forwarder_helpers/*.py
 
 %dir %{python3_sitearch}/samba/tests/emulate
-%{python3_sitearch}/samba/tests/emulate/__init__.py
+%{python3_sitearch}/samba/tests/emulate/*.py
 %dir %{python3_sitearch}/samba/tests/emulate/__pycache__
 %{python3_sitearch}/samba/tests/emulate/__pycache__/*.*.pyc
-%{python3_sitearch}/samba/tests/emulate/*.py
 
 %dir %{python3_sitearch}/samba/tests/kcc
-%{python3_sitearch}/samba/tests/kcc/__init__.py
+%{python3_sitearch}/samba/tests/kcc/*.py
 %dir %{python3_sitearch}/samba/tests/kcc/__pycache__
 %{python3_sitearch}/samba/tests/kcc/__pycache__/*.*.pyc
-%{python3_sitearch}/samba/tests/kcc/*.py
 
 %dir %{python3_sitearch}/samba/tests/samba_tool
-%{python3_sitearch}/samba/tests/samba_tool/__init__.py
+%{python3_sitearch}/samba/tests/samba_tool/*.py
 %dir %{python3_sitearch}/samba/tests/samba_tool/__pycache__
 %{python3_sitearch}/samba/tests/samba_tool/__pycache__/*.*.pyc
-%{python3_sitearch}/samba/tests/samba_tool/*.py
 
 %{python3_sitearch}/samba/tests/krb5/__pycache__/*.*.pyc
 %{python3_sitearch}/samba/tests/krb5/*.py

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1616,7 +1616,6 @@ fi
 %{_libdir}/samba/libtime-basic-samba4.so
 %{_libdir}/samba/libtorture-samba4.so
 %{_libdir}/samba/libtrusts-util-samba4.so
-%{_libdir}/samba/libutil-cmdline-samba4.so
 %{_libdir}/samba/libutil-reg-samba4.so
 %{_libdir}/samba/libutil-setid-samba4.so
 %{_libdir}/samba/libutil-tdb-samba4.so
@@ -1681,11 +1680,6 @@ fi
 
 ### COMMON-libs
 %files common-libs
-# common libraries
-%{_libdir}/samba/libpopt-samba3-cmdline-samba4.so
-%{_libdir}/samba/libpopt-samba3-samba4.so
-
-# here???
 %{_libdir}/libdcerpc-server-core.so
 %{_libdir}/libdcerpc-server-core.so.*
 

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2367,6 +2367,7 @@ fi
 %{_libexecdir}/ctdb/ctdb_recovery_helper
 %{_libexecdir}/ctdb/ctdb_takeover_helper
 %{_libexecdir}/ctdb/smnotify
+%{_libexecdir}/ctdb/tdb_mutex_check
 
 %dir %{_localstatedir}/lib/ctdb/
 %dir %{_localstatedir}/lib/ctdb/persistent


### PR DESCRIPTION
Following libraries were removed:
* [popt_samba3](https://git.samba.org/?p=samba.git;a=commit;h=c377845d27d4dcd7c1791e8b2b42b0f21c9d8bf3)
* [util-cmdline](https://git.samba.org/?p=samba.git;a=commit;h=f753e2f7acf8f3394a5f1107344d0323acc05694)

New utility added:
* [tdb_mutex_check](https://git.samba.org/?p=samba.git;a=commit;h=cb55b68b3e63b438f4695e362ffa8faae47d0aee) 