### PR TITLE
Build fixes

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1555,7 +1555,6 @@ fi
 %{_libdir}/samba/libclidns-samba4.so
 %{_libdir}/samba/libcluster-samba4.so
 %{_libdir}/samba/libcmdline-contexts-samba4.so
-%{_libdir}/samba/libcmdline-credentials-samba4.so
 %{_libdir}/samba/libcmdline-samba4.so
 %{_libdir}/samba/libcommon-auth-samba4.so
 %{_libdir}/samba/libctdb-event-client-samba4.so

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1710,6 +1710,7 @@ fi
 %{_bindir}/net
 %{_bindir}/pdbedit
 %{_bindir}/profiles
+%{_bindir}/samba-tool
 %{_bindir}/smbcontrol
 %{_bindir}/smbpasswd
 %{_bindir}/testparm


### PR DESCRIPTION
Two new changes:

* [Removal of popt cmdline parser library](https://git.samba.org/?p=samba.git;a=commit;h=9f514b37fbe5a87b78ecba9f0518ca791d6919b8)
* [`samba-tool` enabled without AD DC](https://git.samba.org/?p=samba.git;a=commit;h=9f514b37fbe5a87b78ecba9f0518ca791d6919b8)