### PR TITLE
Enable firewall for ports 49152-60999/tcp

### DIFF
--- a/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
@@ -8,6 +8,13 @@
 - name: Enable firewall rules for gluster
   firewalld: service=glusterfs permanent=yes state=enabled
 
+- name: Add firewalld ports
+  firewalld:
+    port: 49152-60999/tcp
+    permanent: true
+    state: enabled
+    zone: 'public'
+
 - name: Ensure glusterd service is enabled
   service: name=glusterd state=started enabled=yes
 


### PR DESCRIPTION
The current firewall setup for firewalld service glusterd only opens
port ranges 49152-49664. This is causing problems as the latest changes
to glusterfs seems to pick a higher value.

Work around this problem by manually enabling ports 49152 to 60999 until
a more permanent fix is found.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>