### PR TITLE
Remove temporary workaround for firewall ports

### DIFF
--- a/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/glusterfs.setup/tasks/main.yml
@@ -8,16 +8,6 @@
 - name: Enable firewall rules for gluster
   firewalld: service=glusterfs permanent=yes state=enabled
 
-# Workaround for firewall issues
-# https://github.com/gluster/glusterfs/pull/2604
-- name: Add firewalld ports
-  firewalld:
-    port: 49152-60999/tcp
-    permanent: yes
-    immediate: yes
-    state: enabled
-    zone: 'public'
-
 - name: Ensure glusterd service is enabled
   service: name=glusterd state=started enabled=yes
 


### PR DESCRIPTION
Required ports are now being opened up by glusterfs.xml firewall configuration file within installed rpms. See the following commit which implements the change:

https://github.com/gluster/glusterfs/commit/22eed34454b7b4f82fd8dbddb843e24f02065212