### PR TITLE
Remove unpackaged files from buildroot

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1055,6 +1055,8 @@ for i in \
     %{python3_sitearch}/samba/dcerpc/dnsserver.*.so \
     %{python3_sitearch}/samba/dnsserver.py \
     %{python3_sitearch}/samba/domain_update.py \
+    %{python3_sitearch}/samba/dsdb.*.so \
+    %{python3_sitearch}/samba/dsdb_dns.*.so \
     %{python3_sitearch}/samba/forest_update.py \
     %{python3_sitearch}/samba/kcc/__init__.py \
     %{python3_sitearch}/samba/kcc/debug.py \
@@ -2090,10 +2092,6 @@ fi
 %{python3_sitearch}/samba/dcerpc/*.py
 %{python3_sitearch}/samba/dcerpc/*.*.so
 
-# pydsdb is built without ad dc but requires dc components
-%exclude %{python3_sitearch}/samba/dsdb.*.so
-%exclude %{python3_sitearch}/samba/dsdb_dns.*.so
-
 %dir %{python3_sitearch}/samba/emulate
 %dir %{python3_sitearch}/samba/emulate/__pycache__
 %{python3_sitearch}/samba/emulate/__pycache__/*.*.pyc
@@ -2151,6 +2149,8 @@ fi
 
 %{python3_sitearch}/samba/dcerpc/dnsserver.*.so
 %{python3_sitearch}/samba/dckeytab.*.so
+%{python3_sitearch}/samba/dsdb.*.so
+%{python3_sitearch}/samba/dsdb_dns.*.so
 %{python3_sitearch}/samba/domain_update.py
 %{python3_sitearch}/samba/forest_update.py
 %{python3_sitearch}/samba/ms_forest_updates_markdown.py


### PR DESCRIPTION
Since pydsdb being built without AD DC in [upstream](https://git.samba.org/?p=samba.git;a=commit;h=a7897cc6cd5ba2df57d354c71b625e98be2a3243), we modified spec file to exclude(see commit fe4d4d02491ab0ee892cf97c69fcd66964a4aa19) the following files from _python3-samba_ sub-package as these will introduce additional dependencies for other libraries that are only built with DC components:

- _/usr/lib64/python3.9/site-packages/samba/dsdb.cpython-39-x86_64-linux-gnu.so_
- _/usr/lib64/python3.9/site-packages/samba/dsdb_dns.cpython-39-x86_64-linux-gnu.so_

Even though it was not required we removed above files from _python3-samba-dc_ sub-package too.

But this triggered a [known issue](https://github.com/rpm-software-management/rpm/issues/1622) with debuginfo(build-ids) processing in a later stage of build process and it fails. This failure can be avoided by conditionally removing above files from the buildroot. Additonally re-introduce those files under _python3-samba-dc_ sub-package.