### PR TITLE
samba: Allow FSCTL control for torture tests

### DIFF
--- a/vagrant/ansible/roles/samba-glusterfs.setup/templates/smb.conf.j2
+++ b/vagrant/ansible/roles/samba-glusterfs.setup/templates/smb.conf.j2
@@ -18,3 +18,4 @@ disable spoolss = yes
 printing = bsd
 show add printer wizard = no
 
+smbd:FSCTL_SMBTORTURE = yes


### PR DESCRIPTION
Adds conf line
smbd:FSCTL_SMBTORTURE = yes
to smb.conf.

This is needed for some smbtorture tests such as multichannel and replay tests where the server behaviour has to be modified(eg: do not ack oplock/lease breaks)  in order to run a test.