### PR TITLE
Enable Samba DC components for Fedora builds

### DIFF
--- a/packaging/samba-4.14.spec.j2
+++ b/packaging/samba-4.14.spec.j2
@@ -64,16 +64,9 @@
 %global with_mitkrb5 1
 %global with_dc 0
 
-%if 0%{?rhel}
-%global with_dc 0
-%endif
-
-%if %{with testsuite}
+%if 0%{?fedora} || %{with testsuite}
 %global with_dc 1
 %endif
-
-#attempt:
-%global with_dc 0
 
 %global required_mit_krb5 1.15.1
 
@@ -206,6 +199,10 @@ BuildRequires: perl(Archive::Tar)
 BuildRequires: perl(Test::More)
 BuildRequires: popt-devel
 BuildRequires: python3-devel
+%if %with_dc
+BuildRequires: python3-dns
+BuildRequires: python3-setuptools
+%endif
 BuildRequires: quota-devel
 BuildRequires: readline-devel
 %if ( ( 0%{?rhel} && 0%{?rhel} >= 8 ) || ( 0%{?fedora} ) )
@@ -235,6 +232,9 @@ BuildRequires: libcephfs-devel
 # Add python3-iso8601 to avoid that the
 # version in Samba is being packaged
 BuildRequires: python3-iso8601
+# lmdb-devel is required for the mdb ldb module, if samba is configured
+# to build includelibs we need lmdb-devel for building that module on our own
+BuildRequires: lmdb-devel
 
 BuildRequires: bind
 BuildRequires: krb5-server >= %{required_mit_krb5}
@@ -917,6 +917,9 @@ export PKG_CONFIG_PATH="/usr/lib64/compat-gnutls34/pkgconfig:/usr/lib64/compat-n
 %if %with_mitkrb5
         --with-system-mitkrb5 \
 %endif
+%if %with_dc
+        --with-experimental-mit-ad-dc \
+%endif
 %if ! %with_dc
         --without-ad-dc \
 %endif
@@ -1503,6 +1506,10 @@ fi
 # this is already contained above
 %{_libdir}/samba/ldb/paged_results.so
 %endif
+%if %with_dc || %{with testsuite}
+%{_libdir}/samba/ldb/mdb.so
+%{_libdir}/samba/libldb-mdb-int-samba4.so
+%endif
 %{_libdir}/samba/ldb/paged_searches.so
 %{_libdir}/samba/ldb/rdn_name.so
 %{_libdir}/samba/ldb/sample.so
@@ -1796,6 +1803,10 @@ fi
 %{_mandir}/man8/samba_downgrade_db.8*
 %{_mandir}/man8/samba-gpupdate.8*
 %{_mandir}/man8/samba-tool.8*
+%dir %{_datadir}/samba/admx
+%{_datadir}/samba/admx/samba.admx
+%dir %{_datadir}/samba/admx/en-US
+%{_datadir}/samba/admx/en-US/samba.adml
 
 %files dc-provision
 %license source4/setup/ad-schema/licence.txt
@@ -1838,6 +1849,8 @@ fi
 %{_libdir}/samba/bind9/dlz_bind9_10.so
 %{_libdir}/samba/bind9/dlz_bind9_11.so
 %{_libdir}/samba/bind9/dlz_bind9_12.so
+%{_libdir}/samba/bind9/dlz_bind9_14.so
+%{_libdir}/samba/bind9/dlz_bind9_16.so
 #endif with_dc
 %endif
 

--- a/packaging/samba-4.15.spec.j2
+++ b/packaging/samba-4.15.spec.j2
@@ -9,8 +9,12 @@
 # ctdb is enabled by default, you can disable it with: --without clustering
 %bcond_without clustering
 
-# DC build components are disabled  by default
+# Build with Active Directory Domain Controller support by default on Fedora
+%if 0%{?fedora} >= 34
+%bcond_without dc
+%else
 %bcond_with dc
+%endif
 
 # Build a libsmbclient package by default
 %bcond_without libsmbclient
@@ -107,7 +111,11 @@
 %global libwbc_alternatives_suffix -64
 %endif
 
+%if %{with dc} || %{with testsuite}
+%global required_mit_krb5 1.19
+%else
 %global required_mit_krb5 1.15.1
+%endif
 
 %global _systemd_extra "Environment=KRB5CCNAME=FILE:/run/samba/krb5cc_samba"
 
@@ -286,9 +294,9 @@ BuildRequires: perl(Parse::Yapp)
 
 # lmdb-devel is required for the mdb ldb module, if samba is configured
 # to build includelibs we need lmdb-devel for building that module on our own
-#BuildRequires: lmdb-devel
+BuildRequires: lmdb-devel
 
-%if %{with testsuite} || %{with dc}
+%if %{with dc} || %{with testsuite}
 BuildRequires: bind
 BuildRequires: krb5-server >= %{required_mit_krb5}
 BuildRequires: ldb-tools
@@ -1064,6 +1072,9 @@ export PKG_CONFIG_PATH="/usr/lib64/compat-gnutls34/pkgconfig:/usr/lib64/compat-n
         --private-libraries=%{_samba_private_libraries} \
 %endif
         --with-system-mitkrb5 \
+%if %{with dc} || %{with testsuite}
+        --with-experimental-mit-ad-dc \
+%endif
 %if %{without dc} && %{without testsuite}
         --without-ad-dc \
 %endif
@@ -1772,6 +1783,9 @@ fi
 
 %{_libdir}/samba/ldb/asq.so
 %{_libdir}/samba/ldb/ldb.so
+%if %{with dc} || %{with testsuite}
+%{_libdir}/samba/ldb/mdb.so
+%endif
 %{_libdir}/samba/ldb/paged_searches.so
 %{_libdir}/samba/ldb/rdn_name.so
 %{_libdir}/samba/ldb/sample.so
@@ -1900,6 +1914,10 @@ fi
 %{_mandir}/man8/samba.8*
 %{_mandir}/man8/samba_downgrade_db.8*
 %{_mandir}/man8/samba-gpupdate.8*
+%dir %{_datadir}/samba/admx
+%{_datadir}/samba/admx/samba.admx
+%dir %{_datadir}/samba/admx/en-US
+%{_datadir}/samba/admx/en-US/samba.adml
 
 %files dc-provision
 %license source4/setup/ad-schema/licence.txt
@@ -1936,11 +1954,11 @@ fi
 %files dc-bind-dlz
 %attr(770,root,named) %dir /var/lib/samba/bind-dns
 %dir %{_libdir}/samba/bind9
-%{_libdir}/samba/bind9/dlz_bind9.so
-%{_libdir}/samba/bind9/dlz_bind9_9.so
 %{_libdir}/samba/bind9/dlz_bind9_10.so
 %{_libdir}/samba/bind9/dlz_bind9_11.so
 %{_libdir}/samba/bind9/dlz_bind9_12.so
+%{_libdir}/samba/bind9/dlz_bind9_14.so
+%{_libdir}/samba/bind9/dlz_bind9_16.so
 #endif {with dc} || {with testsuite}
 %endif
 
@@ -2268,8 +2286,6 @@ fi
 %{python3_sitearch}/samba/__pycache__/schema.*.pyc
 %{python3_sitearch}/samba/__pycache__/uptodateness.*.pyc
 
-%{python3_sitearch}/samba/dcerpc/dnsserver.*.so
-%{python3_sitearch}/samba/dckeytab.*.so
 %{python3_sitearch}/samba/domain_update.py
 %{python3_sitearch}/samba/forest_update.py
 %{python3_sitearch}/samba/ms_forest_updates_markdown.py

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -9,8 +9,12 @@
 # ctdb is enabled by default, you can disable it with: --without clustering
 %bcond_without clustering
 
-# DC build components are disabled  by default
+# Build with Active Directory Domain Controller support by default on Fedora
+%if 0%{?fedora} >= 34
+%bcond_without dc
+%else
 %bcond_with dc
+%endif
 
 # Build a libsmbclient package by default
 %bcond_without libsmbclient
@@ -107,7 +111,11 @@
 %global libwbc_alternatives_suffix -64
 %endif
 
+%if %{with dc} || %{with testsuite}
+%global required_mit_krb5 1.19
+%else
 %global required_mit_krb5 1.15.1
+%endif
 
 %global _systemd_extra "Environment=KRB5CCNAME=FILE:/run/samba/krb5cc_samba"
 
@@ -284,9 +292,9 @@ BuildRequires: perl(Parse::Yapp)
 
 # lmdb-devel is required for the mdb ldb module, if samba is configured
 # to build includelibs we need lmdb-devel for building that module on our own
-#BuildRequires: lmdb-devel
+BuildRequires: lmdb-devel
 
-%if %{with testsuite} || %{with dc}
+%if %{with dc} || %{with testsuite}
 BuildRequires: bind
 BuildRequires: krb5-server >= %{required_mit_krb5}
 BuildRequires: ldb-tools
@@ -1062,6 +1070,9 @@ export PKG_CONFIG_PATH="/usr/lib64/compat-gnutls34/pkgconfig:/usr/lib64/compat-n
         --private-libraries=%{_samba_private_libraries} \
 %endif
         --with-system-mitkrb5 \
+%if %{with dc} || %{with testsuite}
+        --with-experimental-mit-ad-dc \
+%endif
 %if %{without dc} && %{without testsuite}
         --without-ad-dc \
 %endif
@@ -1771,6 +1782,9 @@ fi
 
 %{_libdir}/samba/ldb/asq.so
 %{_libdir}/samba/ldb/ldb.so
+%if %{with dc} || %{with testsuite}
+%{_libdir}/samba/ldb/mdb.so
+%endif
 %{_libdir}/samba/ldb/paged_searches.so
 %{_libdir}/samba/ldb/rdn_name.so
 %{_libdir}/samba/ldb/sample.so
@@ -1899,6 +1913,10 @@ fi
 %{_mandir}/man8/samba.8*
 %{_mandir}/man8/samba_downgrade_db.8*
 %{_mandir}/man8/samba-gpupdate.8*
+%dir %{_datadir}/samba/admx
+%{_datadir}/samba/admx/samba.admx
+%dir %{_datadir}/samba/admx/en-US
+%{_datadir}/samba/admx/en-US/samba.adml
 
 %files dc-provision
 %license source4/setup/ad-schema/licence.txt
@@ -1935,11 +1953,11 @@ fi
 %files dc-bind-dlz
 %attr(770,root,named) %dir /var/lib/samba/bind-dns
 %dir %{_libdir}/samba/bind9
-%{_libdir}/samba/bind9/dlz_bind9.so
-%{_libdir}/samba/bind9/dlz_bind9_9.so
 %{_libdir}/samba/bind9/dlz_bind9_10.so
 %{_libdir}/samba/bind9/dlz_bind9_11.so
 %{_libdir}/samba/bind9/dlz_bind9_12.so
+%{_libdir}/samba/bind9/dlz_bind9_14.so
+%{_libdir}/samba/bind9/dlz_bind9_16.so
 #endif {with dc} || {with testsuite}
 %endif
 
@@ -2267,8 +2285,6 @@ fi
 %{python3_sitearch}/samba/__pycache__/schema.*.pyc
 %{python3_sitearch}/samba/__pycache__/uptodateness.*.pyc
 
-%{python3_sitearch}/samba/dcerpc/dnsserver.*.so
-%{python3_sitearch}/samba/dckeytab.*.so
 %{python3_sitearch}/samba/domain_update.py
 %{python3_sitearch}/samba/forest_update.py
 %{python3_sitearch}/samba/ms_forest_updates_markdown.py


### PR DESCRIPTION
**Samba v4.15.x and above**:
We enable it only for Fedora version >=34 because MIT Kerberos v1.19 is a requirement which is only available with Fedora 34 and above.

**Samba v4.14.x**:
MIT Kerberos requirement is 1.15.1. Therefore DC components are built for all Fedora versions.