### PR TITLE
Workaround name resolution failure with Fedora mock buildroot

### DIFF
--- a/ansible/roles/build.rpms.fedora/tasks/main.yml
+++ b/ansible/roles/build.rpms.fedora/tasks/main.yml
@@ -1,2 +1,2 @@
 - name: build fedora {{ version }} rpms
-  command: /usr/bin/mock --root {{ mock_dir }}/fedora-{{ version }}-x86_64.cfg --resultdir {{ rpms_dir }}/{{ samba_major_version }}/fedora/{{ version }}/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}
+  command: /usr/bin/mock --root {{ mock_dir }}/fedora-{{ version }}-x86_64.cfg --isolation=simple --resultdir {{ rpms_dir }}/{{ samba_major_version }}/fedora/{{ version }}/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}


### PR DESCRIPTION
With Fedora 35 and above, we have name resolution failure within mock buildroot which has been detailed in the following bug report:

https://bugzilla.redhat.com/show_bug.cgi?id=2007758

As mentioned in the bug we have to use a different isolation mechanism other than systemd npsawn containers till fixes are available.

Closes: #207 