### PR TITLE
Fix samba-dcerpcd issue by requiring higher GnuTLS on CentOS 7

### DIFF
--- a/ansible/roles/test.rpms.centos/tasks/main.yml
+++ b/ansible/roles/test.rpms.centos/tasks/main.yml
@@ -25,7 +25,7 @@
     - name: modify copr repo to only use it for compat-gnutls packages
       lineinfile:
         dest: /etc/yum.repos.d/_copr_sergiomb-SambaAD.repo
-        line: "includepkgs=compat-gnutls34.* compat-nettle32.*"
+        line: "includepkgs=compat-gnutls37.* compat-nettle37.* gmp.*"
         insertafter: '\[copr:copr.fedorainfracloud.org:sergiomb:SambaAD\]'
 
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'

--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -201,7 +201,7 @@ BuildRequires: flex
 BuildRequires: gawk
 BuildRequires: gnupg2
 %if 0%{?centos} == 7
-BuildRequires: compat-gnutls34-devel
+BuildRequires: compat-gnutls37-devel
 %else
 BuildRequires: gnutls-devel >= 3.4.7
 %endif
@@ -1066,11 +1066,6 @@ export python_LDFLAGS="$(echo %{__global_ldflags} | sed -e 's/-Wl,-z,defs//g')"
 
 # Use the gold linker
 export LDFLAGS="%{__global_ldflags} -fuse-ld=gold"
-
-# centos 7 hack
-%if 0%{?centos} == 7
-export PKG_CONFIG_PATH="/usr/lib64/compat-gnutls34/pkgconfig:/usr/lib64/compat-nettle32/pkgconfig"
-%endif
 
 %configure \
         --enable-fhs \


### PR DESCRIPTION
samba-dcerpcd was recently discovered to be not working well on CentOS 7 due to an issue(see upstream [MR #2327](https://gitlab.com/samba-team/samba/-/merge_requests/2327)) which would then require higher GnuTLS as a solution to the problem. Therefore we make necessary modifications to install newer GnuTLS version on CentOS 7.

* With _compat-gnutls37-devel_ pkgconfig file is correctly placed under _/usr/lib64/pkgconfig/_ different from _compat-gnutls34-devel_ where it used to install under _/usr/lib64/compat-gnutls34/pkgconfig_. Therefore exporting `PKG_CONFIG_PATH` is no longer required.