### PR TITLE
Re-add elasticsearch_mappings.json

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1535,6 +1535,10 @@ fi
 %{_libdir}/samba/vfs/xattr_tdb.so
 %{_libdir}/samba/vfs/widelinks.so
 
+%dir %{_datadir}/samba
+%dir %{_datadir}/samba/mdssvc
+%{_datadir}/samba/mdssvc/elasticsearch_mappings.json
+
 %{_unitdir}/nmb.service
 %{_unitdir}/smb.service
 %attr(1777,root,root) %dir /var/spool/samba


### PR DESCRIPTION
As per the recent upstream [commit](https://git.samba.org/?p=samba.git;a=commit;h=0eecfddd071ea54844c56516dd7adc761be03c27), `elasticsearch_mappings.json` file was removed accidentally during **samba-dcerpcd** rework. This is now installed by default.