### PR TITLE
Revert `0039148` and adapt to new mock release

### DIFF
--- a/ansible/roles/build.rpms.centos8/tasks/main.yml
+++ b/ansible/roles/build.rpms.centos8/tasks/main.yml
@@ -1,2 +1,2 @@
 - name: build centos 8 rpms
-  command: /usr/bin/mock --root {{ mock_dir }}/epel-next-8-x86_64.cfg --enablerepo=Devel --resultdir {{ rpms_dir }}/{{ samba_major_version }}/centos/8/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}
+  command: /usr/bin/mock --root {{ mock_dir }}/centos-stream+epel-next-8-x86_64.cfg --enablerepo=Devel --resultdir {{ rpms_dir }}/{{ samba_major_version }}/centos/8/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}

--- a/ansible/roles/build.rpms.fedora/tasks/main.yml
+++ b/ansible/roles/build.rpms.fedora/tasks/main.yml
@@ -1,2 +1,2 @@
 - name: build fedora {{ version }} rpms
-  command: /usr/bin/mock --root {{ mock_dir }}/fedora-{{ version }}-x86_64.cfg --isolation=simple --resultdir {{ rpms_dir }}/{{ samba_major_version }}/fedora/{{ version }}/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}
+  command: /usr/bin/mock --root {{ mock_dir }}/fedora-{{ version }}-x86_64.cfg --resultdir {{ rpms_dir }}/{{ samba_major_version }}/fedora/{{ version }}/x86_64 --rebuild {{ srpm_dir }}/{{ samba_srpm }}

--- a/ansible/roles/prep.dirs/tasks/main.yml
+++ b/ansible/roles/prep.dirs/tasks/main.yml
@@ -35,7 +35,7 @@
   loop:
     - /etc/mock/epel-7-x86_64.cfg
     - epel-7-sergiomb.tpl
-    - /etc/mock/epel-next-8-x86_64.cfg
+    - /etc/mock/centos-stream+epel-next-8-x86_64.cfg
     - centos-8-Devel.tpl
     - glusterfs-nightly-repo.tpl
 
@@ -57,7 +57,7 @@
 
 - name: adapt epel-next-8 mock config to use additional template
   lineinfile:
-    path: "{{ mock_dir }}/epel-next-8-x86_64.cfg"
+    path: "{{ mock_dir }}/centos-stream+epel-next-8-x86_64.cfg"
     insertafter: EOF
     line: "{{ item }}"
   with_items:


### PR DESCRIPTION
mock [v2.16](https://rpm-software-management.github.io/mock/Release-Notes-2.16) was released 2 months back with [necessary fixes](https://github.com/rpm-software-management/mock/pull/835) and [updates](https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2021-2d0f959e00) are now available with stable EPEL repositories

This reverts commit 0039148e076fd05386978e146dd60a7c5bd5f9c2 and consumes new filename for epel-8 mock configuration