### PR TITLE
Avoid running smb2.twrp

### DIFF
--- a/testcases/smbtorture-test/smbtorture-tests-info.yml
+++ b/testcases/smbtorture-test/smbtorture-tests-info.yml
@@ -22,7 +22,6 @@
 - smb2.session-id
 - smb2.sharemode
 - smb2.tcon
-- smb2.twrp
 - smb2.winattr
 - smb2.durable-open-disconnect
 - smb2.openattr


### PR DESCRIPTION
Running environment for `smb2.twrp` has been changed to `samba3.blackbox.shadow_copy_torture` with recent upstream [change](https://git.samba.org/?p=samba.git;a=commit;h=f734e960eb7ad98808ad8757de51c51d3db86a2b).