### PR TITLE
New CTDB changes

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1202,10 +1202,6 @@ install -m 0644 ctdb/config/ctdb.conf %{buildroot}%{_sysconfdir}/ctdb/ctdb.conf
 
 install -m 0644 %{SOURCE201} packaging/README.downgrade
 
-%if %{with clustering}
-install -m 0644 ctdb/config/ctdb.service %{buildroot}%{_unitdir}
-%endif
-
 # NetworkManager online/offline script
 install -d -m 0755 %{buildroot}%{_prefix}/lib/NetworkManager/dispatcher.d/
 install -m 0755 packaging/NetworkManager/30-winbind-systemd \
@@ -2511,7 +2507,6 @@ fi
 %config(noreplace) %{_sysconfdir}/ctdb/nfs-checks.d/50.rquotad.check
 
 %{_sbindir}/ctdbd
-%{_sbindir}/ctdbd_wrapper
 %{_bindir}/ctdb
 %if %{with testsuite}
 %{_bindir}/ctdb_local_daemons
@@ -2547,7 +2542,6 @@ fi
 %{_mandir}/man1/onnode.1.gz
 %{_mandir}/man1/ltdbtool.1.gz
 %{_mandir}/man1/ping_pong.1.gz
-%{_mandir}/man1/ctdbd_wrapper.1.gz
 %{_mandir}/man5/ctdb.conf.5.gz
 %{_mandir}/man5/ctdb-script.options.5.gz
 %{_mandir}/man5/ctdb.sysconfig.5.gz
@@ -3142,7 +3136,6 @@ fi
 %{_datadir}/ctdb/tests/UNIT/onnode/stubs/ssh
 %dir %{_datadir}/ctdb/tests/UNIT/shellcheck
 %{_datadir}/ctdb/tests/UNIT/shellcheck/base_scripts.sh
-%{_datadir}/ctdb/tests/UNIT/shellcheck/ctdbd_wrapper.sh
 %{_datadir}/ctdb/tests/UNIT/shellcheck/ctdb_helpers.sh
 %{_datadir}/ctdb/tests/UNIT/shellcheck/event_scripts.sh
 %{_datadir}/ctdb/tests/UNIT/shellcheck/functions.sh


### PR DESCRIPTION
See recent [addition](https://git.samba.org/?p=samba.git;a=blobdiff;f=WHATSNEW.txt;h=48f3fcfb09097c1b07b05a0eae6a9a3cb571e1b3;hp=1bdf3a01cfb0381dd650cc25b56b9004a021eaae;hb=39f70481bbd87e764775f66948ecfdace3722d7a;hpb=8deec3bc67c2831ce63ab4812b6f29baab711b50) to WHATSNEW.

Highlights:
* ctdbd_wrapper is no longer used
* ctdb.service is installed along with smb.service and nmb.service
* Removes related test scripts