### PR TITLE
Use more upto date Fedora COPR repo for gluster-ansible

### DIFF
--- a/vagrant/ansible/roles/node.prep/tasks/centos8.yml
+++ b/vagrant/ansible/roles/node.prep/tasks/centos8.yml
@@ -15,3 +15,4 @@
       - lvm2
       - firewalld
       - python3-libsemanage
+      - python3-pexpect

--- a/vagrant/roles/setup.prep/tasks/centos8.yml
+++ b/vagrant/roles/setup.prep/tasks/centos8.yml
@@ -24,7 +24,7 @@
     name: make
     state: installed
 
-- name: add copr to get gluster-ansible from sac
+- name: add copr to get gluster-ansible from godas
   block:
 
     - name: Install yum copr plugin
@@ -33,7 +33,7 @@
         state: latest
 
     - name: add copr to get gluster-ansible
-      command: yum -y copr enable sac/gluster-ansible
+      command: yum -y copr enable godas/gluster-ansible
 
 - name: Install gluster-ansible
   yum:
@@ -44,3 +44,20 @@
       - gluster-ansible-maintenance
       - gluster-ansible-repositories
     state: latest
+
+- name: Install required ansible collections and dependencies
+  block:
+
+    - name: Install ansible collections
+      become: no
+      shell: ansible-galaxy collection install {{ item }}
+      loop:
+        - ansible.posix
+        - gluster.gluster
+        - ovirt.ovirt
+
+    - name: Install ansible collection dependencies
+      pip:
+        name: jmespath
+        executable: pip3.8
+        state: latest


### PR DESCRIPTION
As part of major re-factoring with Ansible v2.10, many modules were removed and are now maintained separately as collections. _**synchronize**_ module is one such example for which we already [install](https://github.com/anoopcs9/samba-centosci/blob/main/jobs/scripts/gluster-integration/gluster-integration.sh#L71) _anisble.posix_ collection explicitly on host. Accordingly changes were also made at `gluster-ansbile` project to require these collections. These changes went unnoticed as `samba-integration` consumed RPMs from an outdated Fedora COPR repository. Therefore we now switch to more maintained repository and install necessary collections within individual nodes.