### PR TITLE
Include Group Policy code from new location

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -2267,6 +2267,11 @@ fi
 %{python3_sitearch}/samba/emulate/__pycache__/*.*.pyc
 %{python3_sitearch}/samba/emulate/*.py
 
+%dir %{python3_sitearch}/samba/gp
+%{python3_sitearch}/samba/gp/*.py
+%dir %{python3_sitearch}/samba/gp/__pycache__
+%{python3_sitearch}/samba/gp/__pycache__/*.*.pyc
+
 %dir %{python3_sitearch}/samba/gp/util
 %{python3_sitearch}/samba/gp/util/*.py
 %dir %{python3_sitearch}/samba/gp/util/__pycache__


### PR DESCRIPTION
Group policy python scripts have been [moved](https://git.samba.org/?p=samba.git;a=commit;h=56f5ea683001d573e9ddeb30e68aae8ba2d742ed) into a new sub directory called _gp_.