### PR TITLE
smbtorture: Fix knownfail entry for `smb2.maximum_allowed`

### DIFF
--- a/testcases/smbtorture-test/selftest/knownfail
+++ b/testcases/smbtorture-test/selftest/knownfail
@@ -117,7 +117,7 @@
 ^samba4.smb2.charset.*.Testing partial surrogate # This test is currently broken
 ^samba3.smb2.charset.*.Testing partial surrogate # This test is currently broken
 ^samba4.*.base.maximum_allowed		# broken until we implement NTCREATEX_OPTIONS_BACKUP_INTENT
-^samba..*.smb2.maximum_allowed
+^samba..*.smb2.maximum_allowed.maximum_allowed
 .*net.api.delshare.*				# DelShare isn't implemented yet
 ^samba4.smb2.oplock.doc
 ^samba4.smb2.lock.valid-request


### PR DESCRIPTION
See upstream [change](https://git.samba.org/?p=samba.git;a=commit;h=c73d666e5abe8717a5ea333a6dae3619d9621d48) for more details.