### PR TITLE
Include GNOME_Settings admx files

### DIFF
--- a/packaging/samba-master.spec.j2
+++ b/packaging/samba-master.spec.j2
@@ -1982,8 +1982,12 @@ fi
 %{_mandir}/man8/samba_downgrade_db.8*
 %dir %{_datadir}/samba/admx
 %{_datadir}/samba/admx/samba.admx
+%{_datadir}/samba/admx/GNOME_Settings.admx
 %dir %{_datadir}/samba/admx/en-US
 %{_datadir}/samba/admx/en-US/samba.adml
+%{_datadir}/samba/admx/en-US/GNOME_Settings.adml
+%dir %{_datadir}/samba/admx/ru-RU
+%{_datadir}/samba/admx/ru-RU/GNOME_Settings.adml
 
 %files dc-provision
 %license source4/setup/ad-schema/licence.txt


### PR DESCRIPTION
Upstream [fixed](https://git.samba.org/?p=samba.git;a=commit;h=853a4ecd838fcb441cbf654894a96ea728bc2efe) admx file names which are now included with DC builds.